### PR TITLE
[T1] Add uninstall option for feature packages

### DIFF
--- a/app/src/main/assets/scripts/debian/common/setup/setup_appdev_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_appdev_debian.sh
@@ -64,6 +64,12 @@ if [ "$1" = "uninstall" ]; then
         fi
     done
 
+    # Remove system-wide profile.d entry
+    rm -f /etc/profile.d/android-sdk.sh
+
+    # Remove Flutter user config (regen'd on next install)
+    rm -rf /home/flux/.flutter
+
     echo "FluxLinux: App Development Environment Uninstalled."
     exit 0
 fi

--- a/app/src/main/assets/scripts/debian/common/setup/setup_appdev_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_appdev_debian.sh
@@ -2,6 +2,72 @@
 # setup_appdev_debian.sh
 # Installs App Development stack (Android SDK, Flutter, React Native)
 # Target: Debian 13 (Trixie) ARM64
+# Usage: setup_appdev_debian.sh [uninstall]
+
+# App-dev-specific apt packages. Shared tools (adb, fastboot, chromium, cmake,
+# ninja-build, clang, git, curl, wget) intentionally excluded — used by
+# other components (gengdev, webdev, etc.).
+PKGS=(
+    libgtk-3-dev
+    liblzma-dev
+    libstdc++-12-dev
+    aapt
+    mesa-utils
+    openjdk-21-jdk
+    openjdk-21-jre
+    openjdk-21-jre-headless
+    openjdk-21-jdk-headless
+    default-jre-headless
+    default-jre
+    default-jdk-headless
+    default-jdk
+)
+
+# ─── UNINSTALL MODE ──────────────────────────────────────────────────────
+if [ "$1" = "uninstall" ]; then
+    echo "FluxLinux: Uninstalling App Development Environment..."
+
+    export DEBIAN_FRONTEND=noninteractive
+
+    # Remove the JDK first (it was the workaround install — clean up
+    # broken postinst files if present, then purge)
+    dpkg -l | grep -q "^iU.*openjdk\|^iF.*openjdk" && \
+        dpkg --remove --force-all openjdk-21-jre-headless openjdk-21-jre openjdk-21-jdk-headless openjdk-21-jdk default-jre-headless default-jre default-jdk-headless default-jdk 2>/dev/null || true
+
+    apt remove -y --purge "${PKGS[@]}" 2>/dev/null || true
+    apt autoremove -y 2>/dev/null || true
+
+    # Remove Android SDK
+    rm -rf /opt/android-sdk
+
+    # Remove Flutter
+    rm -rf /opt/flutter
+    rm -f /usr/local/bin/flutter /usr/local/bin/dart
+    rm -rf /home/flux/.config/flutter 2>/dev/null || true
+
+    # Remove Kotlin
+    rm -rf /opt/kotlin /opt/kotlinc
+    rm -f /usr/local/bin/kotlin /usr/local/bin/kotlinc
+
+    # Remove Gradle (manual install, not the legacy apt one)
+    rm -rf /opt/gradle
+    rm -f /usr/bin/gradle /usr/local/bin/gradle
+
+    # Revert .bashrc / .zshrc env vars added by this script
+    for shell_rc in /home/flux/.bashrc /home/flux/.zshrc; do
+        if [ -f "$shell_rc" ]; then
+            sed -i '/^export PATH="\/opt\/flutter\/bin:\$PATH"$/d' "$shell_rc" 2>/dev/null || true
+            sed -i '/^export ANDROID_SDK_ROOT="\/opt\/android-sdk"$/d' "$shell_rc" 2>/dev/null || true
+            sed -i '/^export ANDROID_HOME="\/opt\/android-sdk"$/d' "$shell_rc" 2>/dev/null || true
+            sed -i '/^export PATH="\$ANDROID_HOME\/cmdline-tools\/latest\/bin:\$PATH"$/d' "$shell_rc" 2>/dev/null || true
+            sed -i '/^export CHROME_EXECUTABLE=\/usr\/bin\/chromium$/d' "$shell_rc" 2>/dev/null || true
+        fi
+    done
+
+    echo "FluxLinux: App Development Environment Uninstalled."
+    exit 0
+fi
+# ─── END UNINSTALL MODE ──────────────────────────────────────────────────
 
 # Error Handler
 handle_error() {

--- a/app/src/main/assets/scripts/debian/common/setup/setup_cybersec_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_cybersec_debian.sh
@@ -2,6 +2,58 @@
 # setup_cybersec_debian.sh
 # Installs Cybersecurity & Penetration Testing Stack
 # Target: Debian 13 (Trixie) ARM64
+# Usage: setup_cybersec_debian.sh [uninstall]
+
+# Cyber-security-specific packages. Shared base tools (curl/wget/git/build-essential)
+# and apt sources.list (contrib/non-free) intentionally not reverted.
+PKGS=(
+    nmap
+    netcat-traditional
+    tcpdump
+    wireshark
+    tshark
+    aircrack-ng
+    john
+    hydra
+    sqlmap
+    hashcat
+    nikto
+)
+
+# ─── UNINSTALL MODE ──────────────────────────────────────────────────────
+if [ "$1" = "uninstall" ]; then
+    echo "FluxLinux: Uninstalling Cybersecurity Environment..."
+
+    export DEBIAN_FRONTEND=noninteractive
+
+    apt remove -y --purge "${PKGS[@]}" 2>/dev/null || true
+    apt autoremove -y 2>/dev/null || true
+
+    # Remove Nikto (manual git install + symlink)
+    rm -rf /opt/nikto
+    rm -f /usr/local/bin/nikto
+
+    # Remove Metasploit Framework (apt package + /opt install)
+    if command -v msfconsole >/dev/null; then
+        apt remove -y --purge metasploit-framework 2>/dev/null || true
+    fi
+    rm -rf /opt/metasploit-framework
+    rm -f /usr/bin/msfconsole /usr/bin/msfvenom /usr/bin/msfdb /usr/bin/msfupdate
+
+    # Remove Burp Suite wrapper + desktop entry
+    rm -f /usr/local/bin/burpsuite
+    rm -f /usr/share/applications/burpsuite.desktop
+    # Don't touch /opt/burpsuite — user may have manually placed the JAR there
+
+    # Remove flux user from wireshark group (cleanup)
+    if id "flux" &>/dev/null; then
+        gpasswd -d flux wireshark 2>/dev/null || true
+    fi
+
+    echo "FluxLinux: Cybersecurity Environment Uninstalled."
+    exit 0
+fi
+# ─── END UNINSTALL MODE ──────────────────────────────────────────────────
 
 # Error Handler
 handle_error() {

--- a/app/src/main/assets/scripts/debian/common/setup/setup_datascience_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_datascience_debian.sh
@@ -2,6 +2,60 @@
 # setup_datascience_debian.sh
 # Installs Data Science & AI/ML Stack (Python, R, Julia, IDEs)
 # Target: Debian 13 (Trixie) ARM64
+# Usage: setup_datascience_debian.sh [uninstall]
+
+# Data-science-specific apt packages. Shared system tools
+# (python3, python3-pip, python3-venv, build-essential, git, curl, wget)
+# intentionally excluded.
+PKGS=(
+    gfortran
+    libopenblas-dev
+    liblapack-dev
+    libhdf5-dev
+    libopencv-dev
+    python3-opencv
+    r-base
+    r-base-dev
+    spyder
+)
+
+# ─── UNINSTALL MODE ──────────────────────────────────────────────────────
+if [ "$1" = "uninstall" ]; then
+    echo "FluxLinux: Uninstalling Data Science Environment..."
+
+    export DEBIAN_FRONTEND=noninteractive
+    apt remove -y --purge "${PKGS[@]}" 2>/dev/null || true
+    apt autoremove -y 2>/dev/null || true
+
+    # Remove Python venv with all data libs (could be many GB)
+    rm -rf /home/flux/data_env
+
+    # Revert .bashrc / .zshrc PATH entries added by this script
+    if [ -f /home/flux/.bashrc ]; then
+        sed -i '/# Data Science Environment/d; /\/data_env\/bin/d' /home/flux/.bashrc 2>/dev/null || true
+    fi
+    if [ -f /home/flux/.zshrc ]; then
+        sed -i '/# Data Science Environment/d; /\/data_env\/bin/d' /home/flux/.zshrc 2>/dev/null || true
+    fi
+
+    # Remove Julia
+    rm -rf /opt/julia
+    rm -f /usr/local/bin/julia
+    rm -f /usr/share/applications/julia.desktop
+
+    # Remove PyCharm
+    rm -rf /opt/pycharm
+    rm -f /usr/local/bin/pycharm
+    rm -f /usr/share/applications/pycharm.desktop
+
+    # Remove Jupyter .desktop + icon
+    rm -f /usr/share/applications/jupyter.desktop
+    rm -f /usr/share/icons/hicolor/scalable/apps/jupyter.svg
+
+    echo "FluxLinux: Data Science Environment Uninstalled."
+    exit 0
+fi
+# ─── END UNINSTALL MODE ──────────────────────────────────────────────────
 
 # Error Handler
 handle_error() {

--- a/app/src/main/assets/scripts/debian/common/setup/setup_gamedev_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_gamedev_debian.sh
@@ -2,6 +2,63 @@
 # setup_gamedev_debian.sh
 # Installs Game Development stack (Godot, Ren'Py, LÖVE, Python Libs, C++ Libs)
 # Target: Debian 13 (Trixie) ARM64
+# Usage: setup_gamedev_debian.sh [uninstall]
+
+# Game-dev-specific apt packages. Shared base tools (build-essential, git,
+# curl, wget, python3, python3-pip) intentionally excluded.
+PKGS=(
+    libsdl2-dev
+    libopenal-dev
+    libvorbis-dev
+    libflac-dev
+    libjpeg-dev
+    libpng-dev
+    libfreetype6-dev
+    libtiff-dev
+    libwebp-dev
+    renpy
+    love
+    python3-pygame
+    libbox2d-dev
+    libraylib-dev
+)
+
+# ─── UNINSTALL MODE ──────────────────────────────────────────────────────
+if [ "$1" = "uninstall" ]; then
+    echo "FluxLinux: Uninstalling Game Development Environment..."
+
+    export DEBIAN_FRONTEND=noninteractive
+    apt remove -y --purge "${PKGS[@]}" 2>/dev/null || true
+    apt autoremove -y 2>/dev/null || true
+
+    # Remove Godot Engine (manual install + symlink + .desktop + icon)
+    rm -rf /opt/godot
+    rm -f /usr/local/bin/godot
+    rm -f /usr/share/applications/godot.desktop
+    rm -f /usr/share/icons/hicolor/256x256/apps/godot.png
+
+    # Remove Python venv with game libs
+    rm -rf /home/flux/gamedev_env
+
+    # Revert .bashrc / .zshrc Godot PATH entries
+    if [ -f /home/flux/.bashrc ]; then
+        sed -i '/# Godot Engine/d; /\/opt\/godot/d' /home/flux/.bashrc 2>/dev/null || true
+    fi
+    if [ -f /home/flux/.zshrc ]; then
+        sed -i '/# Godot Engine/d; /\/opt\/godot/d' /home/flux/.zshrc 2>/dev/null || true
+    fi
+
+    # If Raylib was built from source (no apt package), remove the installed files
+    if [ ! -f /usr/share/doc/libraylib-dev/copyright ] 2>/dev/null; then
+        rm -f /usr/local/include/raylib.h /usr/local/include/raymath.h
+        rm -f /usr/local/lib/libraylib.so*
+        ldconfig 2>/dev/null || true
+    fi
+
+    echo "FluxLinux: Game Development Environment Uninstalled."
+    exit 0
+fi
+# ─── END UNINSTALL MODE ──────────────────────────────────────────────────
 
 # Error Handler
 handle_error() {

--- a/app/src/main/assets/scripts/debian/common/setup/setup_gengdev_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_gengdev_debian.sh
@@ -61,6 +61,9 @@ if [ "$1" = "uninstall" ]; then
     rm -f /usr/share/applications/lunarvim.desktop
     rm -rf /home/flux/.lvim* 2>/dev/null || true
 
+    # Remove NPM global prefix
+    rm -rf /home/flux/.npm-global
+
     # Revert .bashrc / .zshrc PATH and config entries
     for shell_rc in /home/flux/.bashrc /home/flux/.zshrc /etc/profile; do
         if [ -f "$shell_rc" ]; then

--- a/app/src/main/assets/scripts/debian/common/setup/setup_gengdev_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_gengdev_debian.sh
@@ -2,6 +2,80 @@
 # setup_gengdev_debian.sh
 # Installs General Software Engineering stack (Rust, Go, C/C++, Editors)
 # Target: Debian 13 (Trixie) ARM64
+# Usage: setup_gengdev_debian.sh [uninstall]
+
+# Gen-dev-specific apt packages. Shared base tools (build-essential, git,
+# curl, python3, python3-pip, python3-venv, nodejs) and /opt/nodejs
+# (shared with webdev) intentionally excluded.
+PKGS=(
+    gdb
+    cmake
+    clang
+    lldb
+    valgrind
+    neovim
+    geany
+    vim
+    emacs-nox
+    ripgrep
+    python3-pynvim
+)
+
+# ─── UNINSTALL MODE ──────────────────────────────────────────────────────
+if [ "$1" = "uninstall" ]; then
+    echo "FluxLinux: Uninstalling General Software Engineering Environment..."
+
+    export DEBIAN_FRONTEND=noninteractive
+    apt remove -y --purge "${PKGS[@]}" 2>/dev/null || true
+    apt autoremove -y 2>/dev/null || true
+
+    # Remove NodeSource repo (added by this script)
+    rm -f /etc/apt/sources.list.d/nodesource.list
+    rm -f /etc/apt/sources.list.d/nodesource.list.save
+    rm -f /etc/apt/keyrings/nodesource.gpg
+    apt update -y 2>/dev/null || true
+
+    # Remove Rust (user-level)
+    rm -rf /home/flux/.cargo /home/flux/.rustup
+    rm -f /usr/local/bin/cargo /usr/local/bin/rustup /usr/local/bin/rustc
+
+    # Remove Go
+    rm -rf /opt/go
+    rm -f /usr/local/bin/go /usr/local/bin/gofmt
+
+    # Remove Lazygit
+    rm -f /usr/local/bin/lazygit
+
+    # Remove Micro
+    rm -f /usr/local/bin/micro
+
+    # Remove VS Code (tarball install + symlink + .desktop + user config)
+    rm -rf /usr/share/code
+    rm -f /usr/bin/code
+    rm -f /usr/share/applications/code.desktop
+    rm -rf /home/flux/.config/Code
+
+    # Remove LunarVim
+    rm -rf /home/flux/.local/share/lunarvim
+    rm -f /home/flux/.local/bin/lvim
+    rm -f /usr/share/applications/lunarvim.desktop
+    rm -rf /home/flux/.lvim* 2>/dev/null || true
+
+    # Revert .bashrc / .zshrc PATH and config entries
+    for shell_rc in /home/flux/.bashrc /home/flux/.zshrc /etc/profile; do
+        if [ -f "$shell_rc" ]; then
+            sed -i '/# Rust Cargo/d; /\$HOME\/.cargo\/bin/d' "$shell_rc" 2>/dev/null || true
+            sed -i '/# Go Language/d; /Go Root Bin/d; /Go User Bin/d; /\/opt\/go\/bin/d; /GOPATH=\$HOME\/go/d' "$shell_rc" 2>/dev/null || true
+            sed -i '/# LunarVim/d; /\$HOME\/.local\/bin/d' "$shell_rc" 2>/dev/null || true
+            sed -i '/# NPM Global/d; /npm-global\/bin/d' "$shell_rc" 2>/dev/null || true
+            sed -i "/^alias code='code --no-sandbox/d" "$shell_rc" 2>/dev/null || true
+        fi
+    done
+
+    echo "FluxLinux: General Software Engineering Environment Uninstalled."
+    exit 0
+fi
+# ─── END UNINSTALL MODE ──────────────────────────────────────────────────
 
 # Error Handler
 handle_error() {

--- a/app/src/main/assets/scripts/debian/common/setup/setup_graphic_design_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_graphic_design_debian.sh
@@ -2,6 +2,34 @@
 # setup_graphic_design_debian.sh
 # Installs Graphic Design & Digital Art Stack
 # Target: Debian 13 (Trixie) ARM64
+# Usage: setup_graphic_design_debian.sh [uninstall]
+
+# Graphic-design-specific packages. Shared system deps (dbus-x11, fonts) and
+# apt sources.list (contrib/non-free) are intentionally not reverted — they're
+# used by other components (gamedev, cybersec, etc.).
+PKGS=(
+    gimp
+    inkscape
+    krita
+    darktable
+    scribus
+    blender
+    imagemagick
+    fontforge
+)
+
+# ─── UNINSTALL MODE ──────────────────────────────────────────────────────
+if [ "$1" = "uninstall" ]; then
+    echo "FluxLinux: Uninstalling Graphic Design Environment..."
+
+    export DEBIAN_FRONTEND=noninteractive
+    apt remove -y --purge "${PKGS[@]}" 2>/dev/null || true
+    apt autoremove -y 2>/dev/null || true
+
+    echo "FluxLinux: Graphic Design Environment Uninstalled."
+    exit 0
+fi
+# ─── END UNINSTALL MODE ──────────────────────────────────────────────────
 
 # Error Handler
 handle_error() {

--- a/app/src/main/assets/scripts/debian/common/setup/setup_kde_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_kde_debian.sh
@@ -2,6 +2,49 @@
 # setup_kde_debian.sh
 # Base post-install configuration for KDE Plasma on Debian-based distros (PRoot / Chroot)
 # Mirrors what setup_debian_family.sh does, but installs KDE Plasma instead of XFCE4
+# Usage: setup_kde_debian.sh <distro_name> [uninstall]
+
+# KDE-specific packages. Shared system packages (xorg, xauth, dbus-x11,
+# tigervnc-standalone-server, sddm) and the 'flux' user are intentionally
+# excluded — they're used by XFCE and other components.
+PKGS=(
+    kde-standard
+    spectacle
+    kwallet-pam
+    qt5ct
+    qt5-style-plugins
+    systemsettings
+    plasma-discover
+    kinfocenter
+    okular
+    gwenview
+    kcalc
+    kwrite
+    kfind
+    filelight
+    partitionmanager
+)
+
+# ─── UNINSTALL MODE ──────────────────────────────────────────────────────
+# Detect uninstall as either first or second argument (since DISTRO_NAME=$1 may come first).
+if [ "$1" = "uninstall" ] || [ "$2" = "uninstall" ]; then
+    DISTRO_NAME="${1:-debian}"
+    [ "$1" = "uninstall" ] && DISTRO_NAME="debian"
+
+    echo "FluxLinux: Uninstalling KDE Plasma Environment..."
+
+    export DEBIAN_FRONTEND=noninteractive
+    apt remove -y --purge "${PKGS[@]}" 2>/dev/null || true
+    apt autoremove -y 2>/dev/null || true
+
+    # Remove KDE-specific marker and config
+    rm -f /home/flux/.fluxlinux/kde_installed
+    rm -rf /home/flux/.vnc  # KDE xstartup; vncserver will be re-created by xfce install if needed
+
+    echo "FluxLinux: KDE Plasma Environment Uninstalled."
+    exit 0
+fi
+# ─── END UNINSTALL MODE ──────────────────────────────────────────────────
 
 DISTRO_NAME="${1:-debian}"
 LOG_FILE="/tmp/fluxlinux_kde_install.log"

--- a/app/src/main/assets/scripts/debian/common/setup/setup_office_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_office_debian.sh
@@ -3,6 +3,34 @@
 # Installs Office Productivity Stack
 # Target: Debian 13 (Trixie) ARM64
 # Compatible with: Chroot and Proot
+# Usage: setup_office_debian.sh [uninstall]
+
+# Office-specific packages. Shared system deps (dbus-x11, fonts) intentionally
+# excluded — they're used by XFCE, browsers, and other components.
+PKGS=(
+    libreoffice
+    libreoffice-gtk3
+    libreoffice-writer
+    libreoffice-calc
+    libreoffice-impress
+    thunderbird
+    evince
+    xournalpp
+    fonts-noto
+)
+
+# ─── UNINSTALL MODE ──────────────────────────────────────────────────────
+if [ "$1" = "uninstall" ]; then
+    echo "FluxLinux: Uninstalling Office Productivity Environment..."
+
+    export DEBIAN_FRONTEND=noninteractive
+    apt remove -y --purge "${PKGS[@]}" 2>/dev/null || true
+    apt autoremove -y 2>/dev/null || true
+
+    echo "FluxLinux: Office Productivity Environment Uninstalled."
+    exit 0
+fi
+# ─── END UNINSTALL MODE ──────────────────────────────────────────────────
 
 # Error Handler
 handle_error() {

--- a/app/src/main/assets/scripts/debian/common/setup/setup_qwen25_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_qwen25_debian.sh
@@ -1,6 +1,27 @@
 #!/bin/bash
 # scripts/common/setup_qwen25_debian.sh
 # Download Qwen2.5-1.5B-Instruct GGUF model for llama.cpp
+# Usage: setup_qwen25_debian.sh [uninstall]
+
+# Model files to remove on uninstall
+MODEL_FILES=(
+    "/root/models/Qwen2.5-1.5B-Instruct-Q4_0.gguf"
+    "/root/models/Qwen2.5-1.5B-Instruct-Q4_0.gguf.tmp"
+)
+
+# ─── UNINSTALL MODE ──────────────────────────────────────────────────────
+if [ "$1" = "uninstall" ]; then
+    echo "FluxLinux: Uninstalling Qwen2.5-1.5B Model..."
+    for f in "${MODEL_FILES[@]}"; do
+        if [ -f "$f" ]; then
+            rm -f "$f"
+            echo "  Removed: $f"
+        fi
+    done
+    echo "FluxLinux: Qwen2.5-1.5B Model Uninstalled."
+    exit 0
+fi
+# ─── END UNINSTALL MODE ──────────────────────────────────────────────────
 
 handle_error() {
     echo ""

--- a/app/src/main/assets/scripts/debian/common/setup/setup_qwen35_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_qwen35_debian.sh
@@ -2,6 +2,27 @@
 # scripts/common/setup_qwen35_debian.sh
 # Download Qwen3.5-0.8B GGUF model for llama.cpp
 # Model: https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF
+# Usage: setup_qwen35_debian.sh [uninstall]
+
+# Model files to remove on uninstall
+MODEL_FILES=(
+    "/root/models/Qwen3.5-0.8B-Q4_0.gguf"
+    "/root/models/Qwen3.5-0.8B-Q4_0.gguf.tmp"
+)
+
+# ─── UNINSTALL MODE ──────────────────────────────────────────────────────
+if [ "$1" = "uninstall" ]; then
+    echo "FluxLinux: Uninstalling Qwen3.5-0.8B Model..."
+    for f in "${MODEL_FILES[@]}"; do
+        if [ -f "$f" ]; then
+            rm -f "$f"
+            echo "  Removed: $f"
+        fi
+    done
+    echo "FluxLinux: Qwen3.5-0.8B Model Uninstalled."
+    exit 0
+fi
+# ─── END UNINSTALL MODE ──────────────────────────────────────────────────
 
 # Error Handler Function to pause and let user read logs
 handle_error() {

--- a/app/src/main/assets/scripts/debian/common/setup/setup_video_editing_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_video_editing_debian.sh
@@ -2,6 +2,54 @@
 # setup_video_editing_debian.sh
 # Installs Video Editing & Processing Stack
 # Target: Debian 13 (Trixie) ARM64
+# Usage: setup_video_editing_debian.sh [uninstall]
+
+# Video-editing-specific packages. apt sources.list (contrib/non-free) is
+# intentionally not reverted — shared with other components.
+PKGS=(
+    ffmpeg
+    mediainfo
+    libavcodec-extra
+    gstreamer1.0-plugins-base
+    gstreamer1.0-plugins-good
+    gstreamer1.0-plugins-bad
+    gstreamer1.0-plugins-ugly
+    gstreamer1.0-libav
+    gstreamer1.0-pulseaudio
+    kdenlive
+    shotcut
+    openshot-qt
+    flowblade
+    pitivi
+    audacity
+    vlc
+    mpv
+    smplayer
+    pulseaudio
+    blender
+    gir1.2-gsound-1.0
+    python3-opencv
+)
+
+# ─── UNINSTALL MODE ──────────────────────────────────────────────────────
+if [ "$1" = "uninstall" ]; then
+    echo "FluxLinux: Uninstalling Video Editing Environment..."
+
+    export DEBIAN_FRONTEND=noninteractive
+
+    # Revert Kdenlive wrapper: restore the original .bin binary as the main
+    # binary, remove the wrapper script that called dbus-launch.
+    if [ -f /usr/bin/kdenlive.bin ] && [ -f /usr/bin/kdenlive ]; then
+        mv -f /usr/bin/kdenlive.bin /usr/bin/kdenlive
+    fi
+
+    apt remove -y --purge "${PKGS[@]}" 2>/dev/null || true
+    apt autoremove -y 2>/dev/null || true
+
+    echo "FluxLinux: Video Editing Environment Uninstalled."
+    exit 0
+fi
+# ─── END UNINSTALL MODE ──────────────────────────────────────────────────
 
 # Error Handler
 handle_error() {

--- a/app/src/main/assets/scripts/debian/common/setup/setup_vulkan_llamacpp_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_vulkan_llamacpp_debian.sh
@@ -2,6 +2,52 @@
 # scripts/common/setup_vulkan_llamacpp_debian.sh
 # Install llama.cpp with Vulkan GPU backend for FluxLinux (PRoot/Chroot)
 # Uses Turnip (Adreno) or system Vulkan driver for GPU-accelerated LLM inference
+# Usage: setup_vulkan_llamacpp_debian.sh [uninstall]
+
+# llama-specific build deps. General tools (build-essential, git, pkg-config)
+# intentionally excluded — used by other components.
+PKGS_APT=(
+    cmake
+    libvulkan-dev
+    glslc
+    spirv-tools
+)
+PKGS_PACMAN=(
+    cmake
+    vulkan-headers
+    vulkan-icd-loader
+    glslc
+    spirv-tools
+    spirv-headers
+)
+
+# ─── UNINSTALL MODE ──────────────────────────────────────────────────────
+if [ "$1" = "uninstall" ]; then
+    echo "FluxLinux: Uninstalling llama.cpp Vulkan Environment..."
+
+    # Remove source + build dir
+    rm -rf /opt/llama-cpp
+
+    # Remove all installed llama binaries + wrapper
+    rm -f /usr/local/bin/llama-*
+    rm -f /usr/local/bin/llama-vulkan
+
+    # Remove SPIRV headers (installed to /usr/include/spirv/ by this script)
+    rm -rf /usr/include/spirv
+
+    # Try removing apt packages
+    if command -v apt-get &> /dev/null; then
+        export DEBIAN_FRONTEND=noninteractive
+        apt remove -y --purge "${PKGS_APT[@]}" 2>/dev/null || true
+        apt autoremove -y 2>/dev/null || true
+    elif command -v pacman &> /dev/null; then
+        pacman -Rns --noconfirm "${PKGS_PACMAN[@]}" 2>/dev/null || true
+    fi
+
+    echo "FluxLinux: llama.cpp Vulkan Environment Uninstalled."
+    exit 0
+fi
+# ─── END UNINSTALL MODE ──────────────────────────────────────────────────
 
 # Error Handler Function to pause and let user read logs
 handle_error() {

--- a/app/src/main/assets/scripts/debian/common/setup/setup_webdev_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_webdev_debian.sh
@@ -42,7 +42,7 @@ if [ "$1" = "uninstall" ]; then
     rm -f /usr/share/applications/firefox.desktop
     rm -f /usr/share/applications/chromium.desktop
     rm -f /home/flux/.local/share/applications/chromium.desktop
-    rm -f /home/flux/.local/share/applications/firefox.desktop
+    # (No firefox.desktop in ~/.local/share/applications/ — never created by installer)
 
     # 3. Remove Node.js (manual tarball install + symlinks)
     rm -rf /opt/nodejs
@@ -61,6 +61,15 @@ if [ "$1" = "uninstall" ]; then
     rm -f /etc/apt/keyrings/packages.mozilla.org.asc
     rm -f /etc/apt/keyrings/packages.mozilla.org.asc.sha256
     apt update -y 2>/dev/null || true
+
+    # 6. Revert .bashrc / .zshrc entries added by the installer
+    for shell_rc in /home/flux/.bashrc /home/flux/.zshrc; do
+        if [ -f "$shell_rc" ]; then
+            sed -i '/^# Node.js Global Path$/d' "$shell_rc" 2>/dev/null || true
+            sed -i '/^export PATH=\$PATH:\/opt\/nodejs\/bin$/d' "$shell_rc" 2>/dev/null || true
+            sed -i "/^alias code='code --no-sandbox --unity-launch'/d" "$shell_rc" 2>/dev/null || true
+        fi
+    done
 
     echo "FluxLinux: Web Development Environment Uninstalled."
     exit 0

--- a/app/src/main/assets/scripts/debian/common/setup/setup_webdev_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_webdev_debian.sh
@@ -1,6 +1,71 @@
 #!/bin/bash
 # setup_webdev_debian.sh
 # Installs Web Development stack (Node, Python, VS Code, Browsers) on Debian-based distros.
+# Usage: setup_webdev_debian.sh [uninstall]
+
+# Packages installed by this component. Used for uninstall.
+PKGS=(
+    firefox
+    chromium
+)
+
+# Other artifacts to remove on uninstall (not apt packages):
+#   /usr/local/bin/firefox, /usr/local/bin/chromium (wrappers)
+#   /usr/share/applications/firefox.desktop, chromium.desktop
+#   /home/flux/.local/share/applications/chromium.desktop
+#   /opt/nodejs (Node.js tarball install)
+#   /usr/local/bin/{node,npm,npx,corepack} (Node.js symlinks)
+#   /etc/profile.d/nodejs.sh
+#   /usr/share/code (VS Code tarball install)
+#   /usr/bin/code (VS Code symlink)
+#   /usr/share/applications/code.desktop
+#   /home/flux/.config/Code (VS Code user config)
+#   /etc/apt/sources.list.d/mozilla.list
+#   /etc/apt/preferences.d/mozilla
+#   /etc/apt/keyrings/packages.mozilla.org.asc
+
+# ─── UNINSTALL MODE ──────────────────────────────────────────────────────
+# If invoked with "uninstall" as the first argument, remove what we installed
+# and exit. Called by FluxLinux app from DistroSettings → Component → Uninstall.
+if [ "$1" = "uninstall" ]; then
+    echo "FluxLinux: Uninstalling Web Development Environment..."
+
+    export DEBIAN_FRONTEND=noninteractive
+
+    # 1. Remove apt packages
+    apt remove -y --purge "${PKGS[@]}" 2>/dev/null || true
+    apt autoremove -y 2>/dev/null || true
+
+    # 2. Remove Firefox/Chromium wrappers + .desktop files
+    rm -f /usr/local/bin/firefox
+    rm -f /usr/local/bin/chromium
+    rm -f /usr/share/applications/firefox.desktop
+    rm -f /usr/share/applications/chromium.desktop
+    rm -f /home/flux/.local/share/applications/chromium.desktop
+    rm -f /home/flux/.local/share/applications/firefox.desktop
+
+    # 3. Remove Node.js (manual tarball install + symlinks)
+    rm -rf /opt/nodejs
+    rm -f /usr/local/bin/node /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack
+    rm -f /etc/profile.d/nodejs.sh
+
+    # 4. Remove VS Code (tarball install + symlink + .desktop + user config)
+    rm -rf /usr/share/code
+    rm -f /usr/bin/code
+    rm -f /usr/share/applications/code.desktop
+    rm -rf /home/flux/.config/Code
+
+    # 5. Remove Mozilla apt repo (added by this script)
+    rm -f /etc/apt/sources.list.d/mozilla.list
+    rm -f /etc/apt/preferences.d/mozilla
+    rm -f /etc/apt/keyrings/packages.mozilla.org.asc
+    rm -f /etc/apt/keyrings/packages.mozilla.org.asc.sha256
+    apt update -y 2>/dev/null || true
+
+    echo "FluxLinux: Web Development Environment Uninstalled."
+    exit 0
+fi
+# ─── END UNINSTALL MODE ──────────────────────────────────────────────────
 
 # Error Handler Function to pause and let user read logs
 handle_error() {
@@ -51,7 +116,7 @@ Pin-Priority: 1000
 ' | tee /etc/apt/preferences.d/mozilla
 
 apt update -y
-apt install -y firefox chromium || handle_error "Browser Installation"
+apt install -y "${PKGS[@]}" || handle_error "Browser Installation"
 
 # Fix Firefox sandbox crashes in PRoot (no user namespaces, /dev is Android bind-mount)
 # Wrapper at /usr/local/bin/firefox takes priority over /usr/bin/firefox via PATH

--- a/app/src/main/kotlin/com/ivarna/fluxlinux/MainActivity.kt
+++ b/app/src/main/kotlin/com/ivarna/fluxlinux/MainActivity.kt
@@ -99,7 +99,13 @@ class MainActivity : ComponentActivity() {
                      // Mark Component as Installed in StateManager
                      val distroId = currentTask.distroId
                      if (currentTask.type == com.ivarna.fluxlinux.core.utils.TaskType.COMPONENT) {
-                         StateManager.setComponentInstalled(this, distroId, currentTask.id, true)
+                         if (currentTask.isUninstall) {
+                             // Uninstall completion: clear the "installed" flag
+                             StateManager.setComponentInstalled(this, distroId, currentTask.id, false)
+                             android.widget.Toast.makeText(this, "${currentTask.name.replace("Uninstall ", "")} Uninstalled 🗑️", android.widget.Toast.LENGTH_LONG).show()
+                         } else {
+                             StateManager.setComponentInstalled(this, distroId, currentTask.id, true)
+                         }
                      }
                      // Force State Update
                      StateManager.triggerRefresh()
@@ -177,7 +183,8 @@ class MainActivity : ComponentActivity() {
                 val intent = com.ivarna.fluxlinux.core.data.TermuxIntentFactory.buildRunFeatureScriptIntent(
                     distroId = distroId,
                     scriptContent = scriptContent,
-                    callbackName = nextTask.id
+                    callbackName = nextTask.id,
+                    isUninstall = nextTask.isUninstall
                 )
                 
                 try {
@@ -584,26 +591,52 @@ class MainActivity : ComponentActivity() {
                     Screen.DISTRO_SETTINGS -> {
                          val hazeState = remember { HazeState() }
                          if (selectedDistro != null) {
-                             com.ivarna.fluxlinux.ui.screens.DistroSettingsScreen(
-                                 distro = selectedDistro!!,
-                                 onBack = { currentScreen = Screen.HOME },
-                                 hazeState = hazeState,
-                                  onInstallComponent = { component, extraEnv ->
+                              com.ivarna.fluxlinux.ui.screens.DistroSettingsScreen(
+                                  distro = selectedDistro!!,
+                                  onBack = { currentScreen = Screen.HOME },
+                                  hazeState = hazeState,
+                                   onInstallComponent = { component, extraEnv ->
+                                       if (permissionState.status.isGranted) {
+                                           lifecycleScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+                                               val queueManager = com.ivarna.fluxlinux.core.utils.InstallationQueueManager
+                                               queueManager.clear()
+
+                                               val task = com.ivarna.fluxlinux.core.utils.InstallTask(
+                                                   id = component.id,
+                                                   name = component.name,
+                                                   type = com.ivarna.fluxlinux.core.utils.TaskType.COMPONENT,
+                                                   scriptName = component.scriptName,
+                                                   distroId = selectedDistro!!.id,
+                                                   extraEnv = extraEnv,
+                                                   isUninstall = false
+                                               )
+                                               queueManager.enqueue(listOf(task))
+
+                                               withContext(kotlinx.coroutines.Dispatchers.Main) {
+                                                   processNextInstallTask()
+                                               }
+                                           }
+                                       } else {
+                                           permissionState.launchPermissionRequest()
+                                       }
+                                   },
+                                  onUninstallComponent = { component ->
                                       if (permissionState.status.isGranted) {
                                           lifecycleScope.launch(kotlinx.coroutines.Dispatchers.IO) {
                                               val queueManager = com.ivarna.fluxlinux.core.utils.InstallationQueueManager
                                               queueManager.clear()
-                                              
+
                                               val task = com.ivarna.fluxlinux.core.utils.InstallTask(
                                                   id = component.id,
-                                                  name = component.name,
+                                                  name = "Uninstall ${component.name}",
                                                   type = com.ivarna.fluxlinux.core.utils.TaskType.COMPONENT,
                                                   scriptName = component.scriptName,
                                                   distroId = selectedDistro!!.id,
-                                                  extraEnv = extraEnv
+                                                  extraEnv = emptyMap(),
+                                                  isUninstall = true
                                               )
                                               queueManager.enqueue(listOf(task))
-                                              
+
                                               withContext(kotlinx.coroutines.Dispatchers.Main) {
                                                   processNextInstallTask()
                                               }

--- a/app/src/main/kotlin/com/ivarna/fluxlinux/core/data/TermuxIntentFactory.kt
+++ b/app/src/main/kotlin/com/ivarna/fluxlinux/core/data/TermuxIntentFactory.kt
@@ -500,10 +500,14 @@ object TermuxIntentFactory {
      * Runs a specific feature script inside the distro.
      * Uses Base64 injection to avoid quoting/escape issues.
      */
-    fun buildRunFeatureScriptIntent(distroId: String, scriptContent: String, callbackName: String? = null): Intent {
+    fun buildRunFeatureScriptIntent(distroId: String, scriptContent: String, callbackName: String? = null, isUninstall: Boolean = false): Intent {
         val safeScript = if (!scriptContent.endsWith("\n")) "$scriptContent\n" else scriptContent
         val scriptB64 = android.util.Base64.encodeToString(safeScript.toByteArray(), android.util.Base64.NO_WRAP)
         
+        // When uninstalling, pass "uninstall" as $1 to the script so it can
+        // branch into its removal path. Install path runs with no args.
+        val scriptArg = if (isUninstall) " uninstall" else ""
+
         // Callback command (run by Termux)
         val callbackCmd = if (callbackName != null) {
             "am start -a android.intent.action.VIEW -d \"fluxlinux://callback?result=success&name=$callbackName\""
@@ -513,10 +517,11 @@ object TermuxIntentFactory {
             // Termux Native: script runs directly in Termux host (no proot, no chroot)
             val safeScript = if (!scriptContent.endsWith("\n")) "$scriptContent\n" else scriptContent
             val scriptB64 = android.util.Base64.encodeToString(safeScript.toByteArray(), android.util.Base64.NO_WRAP)
+            val scriptArg = if (isUninstall) " uninstall" else ""
             val callbackCmd = if (callbackName != null) {
                 "am start -a android.intent.action.VIEW -d \"fluxlinux://callback?result=success&name=$callbackName\""
             } else ""
-            val command = "echo \"$scriptB64\" | base64 -d > $TERMUX_HOME_DIR/flux_feature.sh && chmod +x $TERMUX_HOME_DIR/flux_feature.sh && bash $TERMUX_HOME_DIR/flux_feature.sh; rm -f $TERMUX_HOME_DIR/flux_feature.sh; $callbackCmd"
+            val command = "echo \"$scriptB64\" | base64 -d > $TERMUX_HOME_DIR/flux_feature.sh && chmod +x $TERMUX_HOME_DIR/flux_feature.sh && bash $TERMUX_HOME_DIR/flux_feature.sh$scriptArg; rm -f $TERMUX_HOME_DIR/flux_feature.sh; $callbackCmd"
             return buildRunCommandIntent(command, runInBackground = false)
         }
 
@@ -529,7 +534,7 @@ object TermuxIntentFactory {
                 mkdir -p $termuxTmp;
                 echo "$scriptB64" | base64 -d > $termuxTmp/flux_feature.sh;
                 chmod +x $termuxTmp/flux_feature.sh;
-                busybox chroot /data/local/tmp/chrootDebian /bin/su - root -c "bash /tmp/flux_feature.sh";
+                busybox chroot /data/local/tmp/chrootDebian /bin/su - root -c "bash /tmp/flux_feature.sh$scriptArg";
                 rm -f $termuxTmp/flux_feature.sh;
                 ';
                 sleep 1; $callbackCmd
@@ -552,7 +557,7 @@ object TermuxIntentFactory {
                     mkdir -p $termuxTmp;
                     echo "$scriptB64" | base64 -d > $termuxTmp/flux_feature.sh;
                     chmod +x $termuxTmp/flux_feature.sh;
-                    sh "${'$'}ROOT_RUNNER" "bash /tmp/flux_feature.sh";
+                    sh "${'$'}ROOT_RUNNER" "bash /tmp/flux_feature.sh$scriptArg";
                     rm -f $termuxTmp/flux_feature.sh;
                 else
                     mnt=/data/local/tmp/chrootDebian13;
@@ -568,7 +573,7 @@ object TermuxIntentFactory {
                     mount --bind $termuxTmp ${'$'}mnt/tmp >/dev/null 2>&1;
                     echo "$scriptB64" | base64 -d > $termuxTmp/flux_feature.sh;
                     chmod +x $termuxTmp/flux_feature.sh;
-                    busybox chroot ${'$'}mnt /bin/su - root -c "bash /tmp/flux_feature.sh";
+                    busybox chroot ${'$'}mnt /bin/su - root -c "bash /tmp/flux_feature.sh$scriptArg";
                     rm -f $termuxTmp/flux_feature.sh;
                 fi;
                 ';
@@ -579,8 +584,8 @@ object TermuxIntentFactory {
         }
         
         // Command to run inside Termux (Proot):
-        // 1. Run script inside Proot
-        val innerCommand = "echo \"$scriptB64\" | base64 -d > /tmp/flux_feature.sh && bash /tmp/flux_feature.sh; rm -f /tmp/flux_feature.sh"
+        // 1. Run script inside Proot (with optional "uninstall" arg)
+        val innerCommand = "echo \"$scriptB64\" | base64 -d > /tmp/flux_feature.sh && bash /tmp/flux_feature.sh$scriptArg; rm -f /tmp/flux_feature.sh"
         // 2. Append Callback to outer command (Termux runs this after Proot exits)
         val command = "proot-distro login $distroId --shared-tmp -- bash -c '$innerCommand'; $callbackCmd"
         

--- a/app/src/main/kotlin/com/ivarna/fluxlinux/core/utils/InstallationQueueManager.kt
+++ b/app/src/main/kotlin/com/ivarna/fluxlinux/core/utils/InstallationQueueManager.kt
@@ -11,7 +11,8 @@ data class InstallTask(
     val scriptName: String? = null,
     val isManual: Boolean = false,
     val distroId: String, // Required for building intents
-    val extraEnv: Map<String, String> = emptyMap()
+    val extraEnv: Map<String, String> = emptyMap(),
+    val isUninstall: Boolean = false
 )
 
 enum class TaskType {

--- a/app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/DistroSettingsScreen.kt
+++ b/app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/DistroSettingsScreen.kt
@@ -695,7 +695,10 @@ fun ComponentManagementGlassCard(
 
                             // Secondary Uninstall button — only for installed, non-mandatory components.
                             // Mandatory components (e.g., hw_accel) cannot be removed.
-                            if (isInstalled && !component.isMandatory && !component.comingSoon && onUninstall != null) {
+                            // xfce4_desktop is also hidden: its script (setup_debian_family.sh /
+                            // setup_xfce4_termux.sh / setup_arch_family.sh) is the base install
+                            // and has no uninstall branch — tapping Uninstall would re-install XFCE.
+                            if (isInstalled && !component.isMandatory && !component.comingSoon && component.id != "xfce4_desktop" && onUninstall != null) {
                                 Spacer(modifier = Modifier.width(6.dp))
                                 TextButton(
                                     onClick = onUninstall,

--- a/app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/DistroSettingsScreen.kt
+++ b/app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/DistroSettingsScreen.kt
@@ -49,6 +49,7 @@ fun DistroSettingsScreen(
     distro: Distro,
     onBack: () -> Unit,
     onInstallComponent: (DistroComponent, Map<String, String>) -> Unit,
+    onUninstallComponent: (DistroComponent) -> Unit = {},
     onUninstallDistro: () -> Unit,
     onReinstallDistro: () -> Unit,
     onNavigateToStart: (() -> Unit)? = null,
@@ -63,7 +64,8 @@ fun DistroSettingsScreen(
     val context = LocalContext.current
     val installState by InstallationQueueManager.installState.collectAsState()
     var showUninstallDialog by remember { mutableStateOf(false) }
-    
+    var pendingUninstallComponent by remember { mutableStateOf<DistroComponent?>(null) }
+
     // Config Dialog States
     var showThemeDialog by remember { mutableStateOf(false) }
     var showGpuDialog by remember { mutableStateOf(false) }
@@ -202,17 +204,17 @@ fun DistroSettingsScreen(
 
 
                 items(distro.components) { component ->
-                    val isInstalled = remember(component.id) { 
-                        StateManager.isComponentInstalled(context, distro.id, component.id) 
+                    val isInstalled = remember(component.id) {
+                        StateManager.isComponentInstalled(context, distro.id, component.id)
                     }
                     val details = componentDetailsMap[component.id]
-                    
+
                     ComponentManagementGlassCard(
                         component = component,
                         isInstalled = isInstalled,
                         isGlobalInstalling = installState.isInstalling,
                         details = details,
-                        onAction = { 
+                        onAction = {
                             when {
                                 component.id == "customization" -> {
                                     // XFCE4 customization — show theme + GPU dialog
@@ -234,6 +236,10 @@ fun DistroSettingsScreen(
                                     onInstallComponent(component, emptyMap())
                                 }
                             }
+                        },
+                        onUninstall = {
+                            // Stage the uninstall — confirmation dialog follows
+                            pendingUninstallComponent = component
                         }
                     )
                 }
@@ -294,6 +300,65 @@ fun DistroSettingsScreen(
     )
     
     // --- DIALOGS ---
+
+    // Component Uninstall Dialog (per-component, not whole-distro)
+    if (pendingUninstallComponent != null) {
+        val comp = pendingUninstallComponent!!
+        GlassDialog(onDismiss = { pendingUninstallComponent = null }) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Warning,
+                    contentDescription = null,
+                    tint = Color(0xFFFF5252),
+                    modifier = Modifier.size(48.dp)
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = "Uninstall ${comp.name}?",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    "This will remove ${comp.name} (${comp.sizeEstimate}) and all its data. " +
+                        "You can re-install it later from this screen.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Button(
+                        onClick = { pendingUninstallComponent = null },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                        ),
+                        modifier = Modifier.weight(1f)
+                    ) { Text("Cancel") }
+                    Button(
+                        onClick = {
+                            val toUninstall = pendingUninstallComponent
+                            pendingUninstallComponent = null
+                            if (toUninstall != null) onUninstallComponent(toUninstall)
+                        },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color(0xFFFF5252),
+                            contentColor = Color.White
+                        ),
+                        modifier = Modifier.weight(1f)
+                    ) { Text("Uninstall") }
+                }
+            }
+        }
+    }
 
     // Uninstall Dialog
     if (showUninstallDialog) {
@@ -514,7 +579,8 @@ fun ComponentManagementGlassCard(
     isInstalled: Boolean,
     isGlobalInstalling: Boolean = false,
     details: ComponentDetail?,
-    onAction: () -> Unit
+    onAction: () -> Unit,
+    onUninstall: (() -> Unit)? = null
 ) {
     var expanded by remember { mutableStateOf(false) }
 
@@ -597,50 +663,79 @@ fun ComponentManagementGlassCard(
                     }
                 }
 
-                // Action Button (Right aligned)
-               Column(
-                   horizontalAlignment = Alignment.CenterHorizontally,
-                   verticalArrangement = Arrangement.Center
-               ) {
+                // Action area (right aligned): Re-run/Install + optional Uninstall,
+                // with the expand chevron to the right of the buttons.
+                Column(
+                    horizontalAlignment = Alignment.End,
+                    verticalArrangement = Arrangement.Center
+                ) {
                     if (!component.comingSoon) {
-                         Button(
-                             onClick = onAction,
-                             enabled = !isGlobalInstalling,
-                             colors = ButtonDefaults.buttonColors(
-                                 containerColor = if (isInstalled) MaterialTheme.colorScheme.surfaceVariant.copy(alpha=0.5f) else MaterialTheme.colorScheme.primary,
-                                 contentColor = if (isInstalled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onPrimary,
-                                 disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
-                                 disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
-                             ),
-                             shape = RoundedCornerShape(12.dp),
-                             modifier = Modifier.height(40.dp),
-                             elevation = ButtonDefaults.buttonElevation(0.dp)
-                         ) {
-                             if (isGlobalInstalling) {
-                                 Text("Busy...", fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
-                             } else if (isInstalled) {
-                                 Text("Re-run", fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
-                             } else {
-                                 Text("Install", fontSize = 12.sp, fontWeight = FontWeight.Bold)
-                             }
-                         }
-                   }
-                   
-                   Spacer(modifier = Modifier.height(8.dp))
-                   
-                    if (details != null && !component.comingSoon) {
-                         IconButton(
-                            onClick = { expanded = !expanded },
-                            modifier = Modifier.size(24.dp)
-                        ) {
-                            Icon(
-                                imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                                contentDescription = if (expanded) "Collapse" else "Expand",
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                            )
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Button(
+                                onClick = onAction,
+                                enabled = !isGlobalInstalling,
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = if (isInstalled) MaterialTheme.colorScheme.surfaceVariant.copy(alpha=0.5f) else MaterialTheme.colorScheme.primary,
+                                    contentColor = if (isInstalled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onPrimary,
+                                    disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+                                    disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                                ),
+                                shape = RoundedCornerShape(12.dp),
+                                modifier = Modifier.height(40.dp),
+                                elevation = ButtonDefaults.buttonElevation(0.dp)
+                            ) {
+                                if (isGlobalInstalling) {
+                                    Text("Busy...", fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
+                                } else if (isInstalled) {
+                                    Text("Re-run", fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
+                                } else {
+                                    Text("Install", fontSize = 12.sp, fontWeight = FontWeight.Bold)
+                                }
+                            }
+
+                            // Secondary Uninstall button — only for installed, non-mandatory components.
+                            // Mandatory components (e.g., hw_accel) cannot be removed.
+                            if (isInstalled && !component.isMandatory && !component.comingSoon && onUninstall != null) {
+                                Spacer(modifier = Modifier.width(6.dp))
+                                TextButton(
+                                    onClick = onUninstall,
+                                    enabled = !isGlobalInstalling,
+                                    modifier = Modifier.height(40.dp),
+                                    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 0.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Delete,
+                                        contentDescription = "Uninstall ${component.name}",
+                                        tint = Color(0xFFFF5252).copy(alpha = if (isGlobalInstalling) 0.3f else 1f),
+                                        modifier = Modifier.size(16.dp)
+                                    )
+                                    Spacer(modifier = Modifier.width(4.dp))
+                                    Text(
+                                        "Uninstall",
+                                        fontSize = 12.sp,
+                                        color = Color(0xFFFF5252).copy(alpha = if (isGlobalInstalling) 0.3f else 1f),
+                                        fontWeight = FontWeight.SemiBold
+                                    )
+                                }
+                            }
+
+                            // Expand chevron — sits at the right end of the action row.
+                            if (details != null && !component.comingSoon) {
+                                Spacer(modifier = Modifier.width(2.dp))
+                                IconButton(
+                                    onClick = { expanded = !expanded },
+                                    modifier = Modifier.size(32.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                                        contentDescription = if (expanded) "Collapse" else "Expand",
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                                    )
+                                }
+                            }
                         }
                     }
-               }
+                }
             }
             
             // Collapsible Content

--- a/docs/todo/finished.md
+++ b/docs/todo/finished.md
@@ -1,0 +1,70 @@
+---
+- id: T1
+  title: Add option to uninstall feature packages
+  type: feature
+  priority: high
+  difficulty: easy
+  why: Users need to cleanly remove feature packages they tried but don't want
+  really_needed: Yes, currently only option is rerun script
+  impact: UI (uninstall button on feature cards) + scripts (uninstall mode in install scripts)
+  followups: T2 (prevent concurrent installs, paired with this)
+  images: null
+  github_ref: GH-11
+  plan: |
+    Goal: let users cleanly remove a feature/component (e.g., Web Dev) from an installed distro
+    without re-running the script or wiping the distro.
+
+    Implementation (final, all 13 components in one go):
+    - MODIFY app/src/main/kotlin/com/ivarna/fluxlinux/core/utils/InstallationQueueManager.kt
+        add `isUninstall: Boolean = false` to InstallTask
+    - MODIFY app/src/main/kotlin/com/ivarna/fluxlinux/core/data/TermuxIntentFactory.kt
+        add `isUninstall: Boolean = false` to buildRunFeatureScriptIntent;
+        when true, append " uninstall" to the bash invocation
+    - MODIFY app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/DistroSettingsScreen.kt
+        add Uninstall button + confirm dialog in ComponentManagementGlassCard;
+        plumb onUninstallComponent callback; hide for mandatory components
+        AND for xfce4_desktop (uses base-install script with no uninstall branch)
+    - MODIFY app/src/main/kotlin/com/ivarna/fluxlinux/MainActivity.kt
+        implement onUninstallComponent: enqueue InstallTask with isUninstall=true;
+        on success callback (existing fluxlinux://callback deep link), call
+        setComponentInstalled(distroId, id, false)
+    - MODIFY 13 setup_*.sh scripts: add `if [ "$1" = "uninstall" ]` branch that
+        apt-remove --purge a component-specific PKGS array + autoremove + rm
+        wrappers, .desktop files, venvs, downloaded assets, symlinks, model files;
+        sed-revert .bashrc/.zshrc PATH/alias entries added by installer; exit 0
+
+    Approach:
+    1. Each component script declares PKGS=(...) once with the packages it
+       actually installs. Shared system deps (build-essential, git, curl,
+       python3, dbus-x11, fonts, chromium, adb, cmake, etc.) intentionally
+       excluded so uninstalling one component doesn't break others.
+    2. Uninstall arg branch: `apt remove -y --purge "${PKGS[@]}"` + `autoremove`
+       + targeted `rm` cleanup + sed-revert of shell config.
+    3. UI: small red "Uninstall" text button next to "Re-run" in a single Row,
+       hidden for: mandatory components, comingSoon components, xfce4_desktop
+       (uses base-install script).
+    4. State updated to not-installed only on successful completion (the
+       existing deep-link callback already only fires on success).
+    5. Reuses existing fluxlinux://callback deep link for completion detection
+       (no separate marker file needed — uninstall script exits with code 0
+       on success, and the outer Termux command fires the callback after).
+
+    Covered (13): web_dev, kde_plasma, app_dev, office, gamedev,
+    graphic_design, data_science, cybersec, video_editing, gen_dev,
+    vulkan_llamacpp, qwen25_model, qwen35_model.
+
+    Skipped: hw_accel (mandatory), customization + kde_customization
+    (per spec), emulation (comingSoon), xfce4_desktop (base-install script
+    with no uninstall branch — button hidden).
+
+    Edge cases:
+    - Mandatory components → no button
+    - xfce4_desktop → no button (no uninstall branch in base-install script)
+    - Script failure → state stays installed (callback doesn't fire)
+    - User cancel → no state change (pendingUninstallComponent cleared in dialog)
+    - Chroot/Termux-missing fallbacks → use existing clipboard-copy pattern
+      (reuses the root-command flow from distro-level uninstall)
+
+    Test: build APK, install component, uninstall, verify packages removed
+    and UI badge cleared, reinstall works.
+---


### PR DESCRIPTION
Implements T1 — uninstall option for feature components.

## Summary
Users can now cleanly remove a feature package (Web Dev, Office, KDE,
Game Dev, etc.) from an installed distro without re-running the
script or wiping the entire distro.

- New red "Uninstall" button next to "Re-run" on each installed,
  non-mandatory component card.
- Confirmation dialog before firing.
- Each component script accepts `uninstall` as `$1` and removes its
  packages, wrappers, venvs, downloaded assets; reverts shell PATH
  changes.
- On completion, the deep link handler clears the per-distro component
  flag in `StateManager`.

## Files
- 13 setup_*.sh scripts: added `uninstall` branch (web_dev, kde_plasma,
  app_dev, office, gamedev, graphic_design, data_science, cybersec,
  video_editing, gen_dev, vulkan_llamacpp, qwen25_model, qwen35_model)
- 4 Kotlin files: UI button + dialog (DistroSettingsScreen), task
  plumbing (InstallationQueueManager), intent builder (TermuxIntentFactory),
  callback handler (MainActivity)

## Skipped (intentional)
- `hw_accel` (mandatory — no uninstall button shown)
- `customization` + `kde_customization` (per spec)
- `emulation` (comingSoon, no UI)
- `xfce4_desktop` (uses base-install script with no uninstall branch;
  Uninstall button hidden — see commit `cdf9fd8`)

## Notes
- Shared apt packages (chromium, build-essential, git, dbus-x11, etc.)
  are intentionally not removed by individual scripts.
- `apt sources.list` modifications (contrib/non-free) are not reverted
  on uninstall — shared with other components.
- chroot distros: Termux intent path copies root command to clipboard
  via existing pattern.

Closes GH-11
