### PR TITLE
[T1.1] Make evince/xournalpp install non-fatal in office

### DIFF
--- a/app/src/main/assets/scripts/debian/common/setup/setup_office_debian.sh
+++ b/app/src/main/assets/scripts/debian/common/setup/setup_office_debian.sh
@@ -95,10 +95,22 @@ apt install -y --no-install-recommends \
 echo "FluxLinux: Installing PDF Tools..."
 # Evince: Document Viewer
 # Xournal++: Note taking & PDF Annotation
+# Non-fatal: on Debian Trixie + backports, evince transitively pulls
+# libgnome-desktop-3 which conflicts with backports' libxkbcommon0.
+# Try, fix, retry; if still fails, warn and continue — LibreOffice can
+# open PDFs anyway.
 apt install -y --no-install-recommends \
     evince \
     xournalpp \
-    || handle_error "PDF Tools Installation"
+    2>/dev/null || {
+        echo " [⚠️] PDF Tools install failed, attempting to fix and retry individually..."
+        apt --fix-broken install -y 2>/dev/null || true
+        dpkg --configure -a 2>/dev/null || true
+        apt install -y --no-install-recommends evince 2>/dev/null || \
+            echo " [⚠️] evince not installed (likely libgnome-desktop-3 / libxkbcommon0 conflict). LibreOffice can still open PDFs."
+        apt install -y --no-install-recommends xournalpp 2>/dev/null || \
+            echo " [⚠️] xournalpp not installed."
+    }
 
 # 5. Optional: Try to install extra fonts (non-fatal if fails)
 echo "FluxLinux: Installing additional fonts (optional)..."


### PR DESCRIPTION
Fix office install failure on Trixie + backports.

## Summary
On Debian 13 (Trixie) with backports enabled, the Office install
script aborted at the PDF Tools step because `evince` transitively
requires `libgnome-desktop-3 → libxkbregistry0 (= 1.7.0-2)`, which
is un-installable when backports' `libxkbcommon0 1.13.x` is present.

`libxkbregistry0` is version-locked to 1.7.0-2, which requires the
older `libxkbcommon0` — backports upgrades it, creating a conflict
that `apt` cannot resolve. The old script called `handle_error` here,
aborting the whole Office install before LibreOffice/Thunderbird got
installed.

## Fix
Wrap the `evince xournalpp` install in a retry/fallback block,
matching the existing pattern used for LibreOffice in the same script:
1. First attempt with both packages (current behavior)
2. On failure: `apt --fix-broken install -y; dpkg --configure -a`
3. Retry: install evince alone
4. Retry: install xournalpp alone
5. If any step still fails, warn and continue — the rest of the
   script completes, LibreOffice/Thunderbird install, user can open
   PDFs via LibreOffice Draw.

The uninstall path (added in T1) is unaffected: PKGS includes both
packages and `apt autoremove` handles missing packages gracefully.

## Testing
Manual: Office card on a clean distro. Install completes with
`[⚠️] evince not installed` warning; LibreOffice + Thunderbird
present; Office uninstall still works; Office reinstall still works.

Closes (part of T1 follow-up)
