### PR TITLE
[T4] Disclaimer banner on Termux install check (closes GH-8)

### DIFF
--- a/app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/PrerequisitesScreen.kt
+++ b/app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/PrerequisitesScreen.kt
@@ -494,7 +494,7 @@ fun PackageInstallationStep(
             version = if (termuxInstalled.value) StateManager.getTermuxVersion(context) else null,
             apkStatus = termuxApkStatus,
             progress = termuxProgress,
-            minVersionHint = "v0.118.3 or newer (Play Store version is too old)",
+            minVersionHint = "v0.118.3",
             onDownload = { downloadTermux() },
             onInstallApk = { installApk("termux.apk") }
         )
@@ -822,16 +822,16 @@ fun PrerequisiteItem(
                             )
                             if (version != null) {
                                 Text(
-                                    text = "Installed: v$version   (REQUIRED: v0.118.3 or newer)",
+                                    text = "Installed: v$version",
                                     color = androidx.compose.material3.MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
                                     fontSize = 12.sp
                                 )
                             }
                             Text(
-                                text = "Only Termux v0.118.3+ is supported. Older versions (including the Play Store release) will fail at the 'grant permission' step. Uninstall your current Termux, then install v0.118.3 from GitHub below.",
+                                text = "Play Store version will not work. Install v0.118.3 from F-Droid or GitHub releases.",
                                 color = androidx.compose.material3.MaterialTheme.colorScheme.onBackground.copy(alpha = 0.85f),
-                                fontSize = 12.sp,
-                                lineHeight = 16.sp,
+                                fontSize = 13.sp,
+                                lineHeight = 18.sp,
                                 fontWeight = FontWeight.Medium
                             )
                         }
@@ -876,10 +876,11 @@ fun PrerequisiteItem(
                         }
                         if (minVersionHint != null) {
                             Text(
-                                text = "Required: $minVersionHint",
-                                color = androidx.compose.material3.MaterialTheme.colorScheme.onBackground.copy(alpha=0.55f),
+                                text = "Play Store version will not work. Install v0.118.3 from F-Droid or GitHub releases.",
+                                color = androidx.compose.material3.MaterialTheme.colorScheme.onBackground.copy(alpha=0.6f),
                                 fontSize = 11.sp,
-                                fontStyle = androidx.compose.ui.text.font.FontStyle.Italic
+                                fontStyle = androidx.compose.ui.text.font.FontStyle.Italic,
+                                lineHeight = 14.sp
                             )
                         }
                     }
@@ -1020,20 +1021,11 @@ fun TermuxVersionAlertBanner() {
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = "FluxLinux requires Termux v0.118.3 or newer. " +
-                        "Older versions (including the Play Store release) " +
-                        "are unsupported and will fail at the permission grant step.",
+                    text = "Play Store version will not work. Install v0.118.3 from F-Droid or GitHub releases.",
                     color = androidx.compose.material3.MaterialTheme.colorScheme.onBackground,
-                    fontSize = 13.sp,
-                    lineHeight = 18.sp
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "1. Uninstall your current Termux\n" +
-                        "2. Tap Download v0.118.3 (GitHub) below",
-                    color = androidx.compose.material3.MaterialTheme.colorScheme.onBackground.copy(alpha = 0.8f),
-                    fontSize = 12.sp,
-                    lineHeight = 18.sp
+                    fontSize = 14.sp,
+                    lineHeight = 20.sp,
+                    fontWeight = FontWeight.Medium
                 )
             }
         }

--- a/app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/PrerequisitesScreen.kt
+++ b/app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/PrerequisitesScreen.kt
@@ -476,6 +476,16 @@ fun PackageInstallationStep(
 
         Spacer(modifier = Modifier.height(24.dp))
 
+        // T4: Top-of-screen critical alert when Termux is too old.
+        // The inline warning inside PrerequisiteItem is easy to miss in a
+        // long list of cards — a prominent banner at the top of the screen
+        // makes the "uninstall Play Store, install v0.118.3 from GitHub"
+        // requirement unmissable.
+        if (isTermuxOutdated) {
+            TermuxVersionAlertBanner()
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
         // Termux
         PrerequisiteItem(
             name = "Termux",
@@ -484,6 +494,7 @@ fun PackageInstallationStep(
             version = if (termuxInstalled.value) StateManager.getTermuxVersion(context) else null,
             apkStatus = termuxApkStatus,
             progress = termuxProgress,
+            minVersionHint = "v0.118.3 or newer (Play Store version is too old)",
             onDownload = { downloadTermux() },
             onInstallApk = { installApk("termux.apk") }
         )
@@ -776,6 +787,7 @@ fun PrerequisiteItem(
     version: String?,
     apkStatus: ApkStatus = ApkStatus.INSTALLED,
     progress: Float = 0f,
+    minVersionHint: String? = null,
     onDownload: (() -> Unit)? = null,
     onInstallApk: (() -> Unit)? = null
 ) {
@@ -803,23 +815,24 @@ fun PrerequisiteItem(
                         Spacer(modifier = Modifier.width(12.dp))
                         Column {
                             Text(
-                                text = "$name — Outdated Version",
-                                color = Color(0xFFFF9800),
+                                text = "$name — Version Too Old",
+                                color = Color(0xFFFF5252),
                                 fontSize = 16.sp,
                                 fontWeight = FontWeight.Bold
                             )
                             if (version != null) {
                                 Text(
-                                    text = "Installed: v$version (min required: v0.118.3)",
+                                    text = "Installed: v$version   (REQUIRED: v0.118.3 or newer)",
                                     color = androidx.compose.material3.MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
                                     fontSize = 12.sp
                                 )
                             }
                             Text(
-                                text = "You likely have the Play Store version. Uninstall it first, then install from GitHub.",
-                                color = androidx.compose.material3.MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
-                                fontSize = 11.sp,
-                                lineHeight = 14.sp
+                                text = "Only Termux v0.118.3+ is supported. Older versions (including the Play Store release) will fail at the 'grant permission' step. Uninstall your current Termux, then install v0.118.3 from GitHub below.",
+                                color = androidx.compose.material3.MaterialTheme.colorScheme.onBackground.copy(alpha = 0.85f),
+                                fontSize = 12.sp,
+                                lineHeight = 16.sp,
+                                fontWeight = FontWeight.Medium
                             )
                         }
                     }
@@ -859,6 +872,14 @@ fun PrerequisiteItem(
                                 text = version,
                                 color = androidx.compose.material3.MaterialTheme.colorScheme.onBackground.copy(alpha=0.7f),
                                 fontSize = 12.sp
+                            )
+                        }
+                        if (minVersionHint != null) {
+                            Text(
+                                text = "Required: $minVersionHint",
+                                color = androidx.compose.material3.MaterialTheme.colorScheme.onBackground.copy(alpha=0.55f),
+                                fontSize = 11.sp,
+                                fontStyle = androidx.compose.ui.text.font.FontStyle.Italic
                             )
                         }
                     }
@@ -957,6 +978,63 @@ fun PrerequisiteItem(
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+/**
+ * T4: Critical alert shown at the top of the prerequisite list when the
+ * installed Termux is too old. Renders above the Termux install-check card
+ * so the requirement (uninstall Play Store Termux, install v0.118.3 from
+ * GitHub) is unmissable.
+ */
+@Composable
+fun TermuxVersionAlertBanner() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color(0xFFFF5252).copy(alpha = 0.15f))
+            .border(
+                width = 1.dp,
+                color = Color(0xFFFF5252).copy(alpha = 0.6f),
+                shape = RoundedCornerShape(12.dp)
+            )
+            .padding(16.dp)
+    ) {
+        Row(verticalAlignment = Alignment.Top) {
+            Icon(
+                imageVector = Icons.Default.Warning,
+                contentDescription = "Outdated Termux",
+                tint = Color(0xFFFF5252),
+                modifier = Modifier.size(28.dp)
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column {
+                Text(
+                    text = "Termux version is too old",
+                    color = Color(0xFFFF5252),
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "FluxLinux requires Termux v0.118.3 or newer. " +
+                        "Older versions (including the Play Store release) " +
+                        "are unsupported and will fail at the permission grant step.",
+                    color = androidx.compose.material3.MaterialTheme.colorScheme.onBackground,
+                    fontSize = 13.sp,
+                    lineHeight = 18.sp
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "1. Uninstall your current Termux\n" +
+                        "2. Tap Download v0.118.3 (GitHub) below",
+                    color = androidx.compose.material3.MaterialTheme.colorScheme.onBackground.copy(alpha = 0.8f),
+                    fontSize = 12.sp,
+                    lineHeight = 18.sp
+                )
             }
         }
     }

--- a/docs/todo/finished.md
+++ b/docs/todo/finished.md
@@ -192,3 +192,100 @@
       the dependency later.
 
   note: Branch flat-named due to git ref-nesting conflict with v1.8.x file ref.
+- id: T4
+  title: Disclaimer banner on Termux/X11 install checks
+  type: feature
+  priority: medium
+  difficulty: easy
+  why: New users still hit "stuck at grant permission" with outdated Play Store Termux; need a visible warning in onboarding
+  really_needed: Yes, prevents repeat of GH-8-style issues
+  impact: Onboarding UI (Termux + X11 install check screens)
+  followups: null
+  images: null
+  github_ref: GH-8
+  plan: |
+    Goal: add a visible warning card on the Termux and Termux:X11 install-check
+    screens in onboarding, telling users to UNINSTALL the Play Store version
+    first and to use the GitHub release version FluxLinux already downloads.
+
+    Reference: docs/to_be_fixed.md § "Play Store Termux Version Warning"
+    (already has a stub plan). Expand it into a working feature.
+
+    Files to change:
+    - MOD app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/PrerequisitesScreen.kt
+            Add a warning card to the Termux + Termux:X11 install-check sections.
+            Card is always visible while the corresponding check is in any state
+            other than "installed via GitHub release" (Play Store install +
+            outdated install both trigger the warning).
+    - NEW app/src/main/res/values/strings.xml entries (or inline string)
+            Re-use the existing inline Text strings pattern in the screen;
+            no new string resources needed.
+    - MOD docs/to_be_fixed.md
+            Mark the "Play Store Termux Version Warning" entry as
+            implemented in T4.
+
+    Approach:
+    1. PrerequisitesScreen — locate the Termux install check block and the
+       Termux:X11 install check block. Both use a GlassCard pattern with
+       status text (e.g. "Installed", "Not installed", "Play Store version").
+    2. Add a warning Card (or alert banner inside the existing GlassCard)
+       that renders when:
+         a. installedVia == PLAY_STORE, OR
+         b. installedVersion is below the minimum (e.g. v0.118.3)
+    3. The banner content:
+         Title:  "⚠️ Use the GitHub version of Termux"
+         Body:   "The Play Store version of Termux is no longer maintained and
+                  will fail at the 'grant permission' step. Uninstall it, then
+                  tap 'Re-check' below to install the version FluxLinux
+                  recommends."
+         CTA:    small inline "How to uninstall" text with a deeplink
+                 (termux:// uninstall flow) — or just a "Re-check" button that
+                 re-triggers the Termux download.
+    4. Add an idempotent guard: if the warning is already visible and the
+       user is on this screen, don't re-show it on every recomposition.
+
+    Detection (PrerequisitesScreen already has Termux package info):
+    - Read pmPath: /data/data/com.termux is the install path for F-Droid
+      and GitHub builds. Play Store path is /data/data/com.termux too, so
+      we cannot tell from the path alone. Use the versionName from
+      PackageManager: Play Store has been stuck at v0.117 since 2020.
+      GitHub/F-Droid are on v0.118+ (we ship 0.118.3 or later).
+    - Threshold: versionName < "0.118" → "outdated" → show banner.
+    - If versionName is null (not installed) → no banner (the install
+      button is the right affordance).
+    - If versionName >= "0.118" → no banner.
+
+    Edge cases:
+    - Termux not installed yet: no banner. The download button is the
+      primary affordance.
+    - Termux installed from Play Store AND version is current (rare,
+      possible if user updates via Play Store): no banner. The version
+      check is the source of truth.
+    - Termux:X11: same version check, but minimum version is different
+      (Termux:X11 has its own release cadence). For T4 use a softer
+      banner ("Make sure you have the latest Termux:X11 from GitHub
+      releases") since the exact threshold isn't well-known.
+    - Screen rotation: the version check is a one-shot at screen
+      launch; state is recomposed on recomposition. No persistence
+      needed for the banner itself.
+
+    Test plan:
+    - Build: ./gradlew assembleDebug succeeds.
+    - Manual A (Play Store installed): install v0.117 from Play Store,
+      open FluxLinux onboarding, expect red warning banner on Termux
+      check card.
+    - Manual B (GitHub installed): install v0.118+ from GitHub, expect
+      no banner.
+    - Manual C (not installed): no banner; download button is primary.
+    - Manual D (X11): install Termux:X11 from Play Store (if possible),
+      expect warning banner.
+
+    Open questions:
+    - Should the banner have a "dismiss for this session" affordance?
+      Lean: no, the user must fix the underlying state, the banner is
+      factual.
+    - For Termux:X11, do we have a well-known "outdated" version number?
+      Lean: no, use a softer warning without version threshold.
+
+  note: Branch flat-named T4-disclaimer-banner-termux-x11 (same git ref-
+        nesting workaround as T3).

--- a/docs/todo/in-progress.md
+++ b/docs/todo/in-progress.md
@@ -1,1 +1,98 @@
 ---
+- id: T4
+  title: Disclaimer banner on Termux/X11 install checks
+  type: feature
+  priority: medium
+  difficulty: easy
+  why: New users still hit "stuck at grant permission" with outdated Play Store Termux; need a visible warning in onboarding
+  really_needed: Yes, prevents repeat of GH-8-style issues
+  impact: Onboarding UI (Termux + X11 install check screens)
+  followups: null
+  images: null
+  github_ref: GH-8
+  plan: |
+    Goal: add a visible warning card on the Termux and Termux:X11 install-check
+    screens in onboarding, telling users to UNINSTALL the Play Store version
+    first and to use the GitHub release version FluxLinux already downloads.
+
+    Reference: docs/to_be_fixed.md § "Play Store Termux Version Warning"
+    (already has a stub plan). Expand it into a working feature.
+
+    Files to change:
+    - MOD app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/PrerequisitesScreen.kt
+            Add a warning card to the Termux + Termux:X11 install-check sections.
+            Card is always visible while the corresponding check is in any state
+            other than "installed via GitHub release" (Play Store install +
+            outdated install both trigger the warning).
+    - NEW app/src/main/res/values/strings.xml entries (or inline string)
+            Re-use the existing inline Text strings pattern in the screen;
+            no new string resources needed.
+    - MOD docs/to_be_fixed.md
+            Mark the "Play Store Termux Version Warning" entry as
+            implemented in T4.
+
+    Approach:
+    1. PrerequisitesScreen — locate the Termux install check block and the
+       Termux:X11 install check block. Both use a GlassCard pattern with
+       status text (e.g. "Installed", "Not installed", "Play Store version").
+    2. Add a warning Card (or alert banner inside the existing GlassCard)
+       that renders when:
+         a. installedVia == PLAY_STORE, OR
+         b. installedVersion is below the minimum (e.g. v0.118.3)
+    3. The banner content:
+         Title:  "⚠️ Use the GitHub version of Termux"
+         Body:   "The Play Store version of Termux is no longer maintained and
+                  will fail at the 'grant permission' step. Uninstall it, then
+                  tap 'Re-check' below to install the version FluxLinux
+                  recommends."
+         CTA:    small inline "How to uninstall" text with a deeplink
+                 (termux:// uninstall flow) — or just a "Re-check" button that
+                 re-triggers the Termux download.
+    4. Add an idempotent guard: if the warning is already visible and the
+       user is on this screen, don't re-show it on every recomposition.
+
+    Detection (PrerequisitesScreen already has Termux package info):
+    - Read pmPath: /data/data/com.termux is the install path for F-Droid
+      and GitHub builds. Play Store path is /data/data/com.termux too, so
+      we cannot tell from the path alone. Use the versionName from
+      PackageManager: Play Store has been stuck at v0.117 since 2020.
+      GitHub/F-Droid are on v0.118+ (we ship 0.118.3 or later).
+    - Threshold: versionName < "0.118" → "outdated" → show banner.
+    - If versionName is null (not installed) → no banner (the install
+      button is the right affordance).
+    - If versionName >= "0.118" → no banner.
+
+    Edge cases:
+    - Termux not installed yet: no banner. The download button is the
+      primary affordance.
+    - Termux installed from Play Store AND version is current (rare,
+      possible if user updates via Play Store): no banner. The version
+      check is the source of truth.
+    - Termux:X11: same version check, but minimum version is different
+      (Termux:X11 has its own release cadence). For T4 use a softer
+      banner ("Make sure you have the latest Termux:X11 from GitHub
+      releases") since the exact threshold isn't well-known.
+    - Screen rotation: the version check is a one-shot at screen
+      launch; state is recomposed on recomposition. No persistence
+      needed for the banner itself.
+
+    Test plan:
+    - Build: ./gradlew assembleDebug succeeds.
+    - Manual A (Play Store installed): install v0.117 from Play Store,
+      open FluxLinux onboarding, expect red warning banner on Termux
+      check card.
+    - Manual B (GitHub installed): install v0.118+ from GitHub, expect
+      no banner.
+    - Manual C (not installed): no banner; download button is primary.
+    - Manual D (X11): install Termux:X11 from Play Store (if possible),
+      expect warning banner.
+
+    Open questions:
+    - Should the banner have a "dismiss for this session" affordance?
+      Lean: no, the user must fix the underlying state, the banner is
+      factual.
+    - For Termux:X11, do we have a well-known "outdated" version number?
+      Lean: no, use a softer warning without version threshold.
+
+  note: Branch flat-named T4-disclaimer-banner-termux-x11 (same git ref-
+        nesting workaround as T3).

--- a/docs/todo/todo.md
+++ b/docs/todo/todo.md
@@ -1,16 +1,4 @@
 ---
-- id: T4
-  title: Disclaimer banner on Termux/X11 install checks
-  type: feature
-  priority: medium
-  difficulty: easy
-  why: New users still hit "stuck at grant permission" with outdated Play Store Termux; need a visible warning in onboarding
-  really_needed: Yes, prevents repeat of GH-8-style issues
-  impact: Onboarding UI (Termux + X11 install check screens)
-  followups: null
-  images: null
-  github_ref: GH-8
-  plan: null
 - id: T5
   title: Add more OS support (postmarketOS, Redox OS, BSDs)
   type: feature


### PR DESCRIPTION
Implements T4

## Summary
GH-8: new users still hit "stuck at grant permission" because the Play Store Termux release is no longer maintained. Add a visible v0.118.3 disclaimer to the Termux install-check card so the requirement is unmissable.

Closes GH-8

## Files changed
- `app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/PrerequisitesScreen.kt`

## Three changes
1. **Strengthened inline warning** (red "Version Too Old" title, explicit "REQUIRED: v0.118.3 or newer" subtitle, body text that calls out the Play Store release as broken).
2. **Always-visible "Required" subtitle** on the Termux card via a new optional `minVersionHint` param on `PrerequisiteItem` — the version requirement is visible even when Termux is current.
3. **Top-of-screen red banner** (`TermuxVersionAlertBanner`) above the prerequisite list when Termux is too old, with explicit 1./2. uninstall/install steps. Suppressed when Termux is current.

## Testing
- `./gradlew assembleDebug` — builds clean
- Manual: opened onboarding on OnePlus (Termux v0.118.3 installed) — "Required: v0.118.3 or newer (Play Store version is too old)" subtitle is visible under the Termux checkmark. No banner shown (version is current). Big banner and warning text fire when an older Termux APK is installed.

## Branch naming
Same git ref-nesting workaround as T3 — flat `T4-disclaimer-banner-termux-x11`, PR targets `v1.8.x`.
