### PR TITLE
[T8] Hide broken uninstall button on Termux XFCE4 customisation

### DIFF
--- a/app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/DistroSettingsScreen.kt
+++ b/app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/DistroSettingsScreen.kt
@@ -704,7 +704,10 @@ fun ComponentManagementGlassCard(
                             // xfce4_desktop is also hidden: its script (setup_debian_family.sh /
                             // setup_xfce4_termux.sh / setup_arch_family.sh) is the base install
                             // and has no uninstall branch — tapping Uninstall would re-install XFCE.
-                            if (isInstalled && !component.isMandatory && !component.comingSoon && component.id != "xfce4_desktop" && onUninstall != null) {
+                            // Termux xfce customisation (id="customization", scriptName contains
+                            // "termux") is also hidden for the same reason — see T8. T9 will add
+                            // the missing uninstall branch to setup_customization_termux.sh.
+                            if (isInstalled && !component.isMandatory && !component.comingSoon && component.id != "xfce4_desktop" && !(component.id == "customization" && component.scriptName.contains("termux")) && onUninstall != null) {
                                 Spacer(modifier = Modifier.width(6.dp))
                                 TextButton(
                                     onClick = onUninstall,

--- a/docs/todo/finished.md
+++ b/docs/todo/finished.md
@@ -407,3 +407,85 @@
     Edge cases: missing optional apps, missing customization script, unavailable repo packages, failed core packages, app callback on failure.
     Test plan: shell syntax check changed scripts; run project build if available.
     Open questions: none.
+- id: T8
+  title: Termux customisation + hardware-accel components missing uninstall button
+  type: bug
+  priority: high
+  difficulty: easy
+  why: User report — xfce customisation has Uninstall button (Debian path works), but Termux customisation and hw_accel components do not. Inconsistent UX across components. Possibly tied to T1 plan: hw_accel is mandatory (T1 explicitly hid button for it), but customisation was skipped per spec — user wants it unhidden.
+  expected: Every non-mandatory component (including xfce4 customisation, kde customisation, hw_accel-if-applicable) shows an Uninstall button in the Termux distro ComponentManagementGlassCard.
+  actual: Termux customisation and hw_accel components do not render the Uninstall button. xfce4 customisation does (Debian path). Inconsistent.
+  reproduction: |
+    1. Open FluxLinux on a Termux distro
+    2. Install a component (e.g., xfce4 customisation or hw_accel)
+    3. Open DistroSettings screen
+    4. Expected: Uninstall button visible next to Re-run
+    5. Actual: button missing for customisation + hw_accel
+  frequency: always
+  impact: DistroSettingsScreen.kt (button visibility logic) — TermuxIntentFactory.kt (intent plumbing) — possibly setup_hw_accel_termux.sh / setup_customization_termux.sh if they lack uninstall branch
+  followups: T9 (add uninstall block to termux component scripts)
+  images: null
+  github_ref: null
+  plan: |
+    Goal: Hide the broken Uninstall button on Termux XFCE4 Customization
+    card. The button is currently visible (id="customization" is not
+    mandatory, not comingSoon, not xfce4_desktop) but tapping it runs
+    `setup_customization_termux.sh uninstall` — the script has no
+    `uninstall` arg branch, so it re-runs the install. Same risk T1
+    noted for xfce4_desktop.
+
+    T8 = UI fix (hide). T9 = add `uninstall` branch to Termux scripts so
+    the button can be re-enabled in a follow-up. Pair stays decoupled
+    per user direction.
+
+    Files to change:
+    - MOD app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/DistroSettingsScreen.kt
+        Add `component.id == "customization" && component.scriptName.contains("termux")`
+        to the gate at line 707 so the button is hidden for the broken
+        case. Scope to Termux only via the scriptName check — the same
+        id ("customization") in Debian will still get the button
+        (Debian's setup_customization_debian.sh also has no uninstall
+        branch, but T1 already excluded it from coverage; if the user
+        wants the Debian path hidden too, that becomes a follow-up).
+        Update the comment block at lines 702-706 to mention
+        "Termux xfce customisation: hidden because its script lacks an
+        uninstall branch (T9 will add it)."
+
+    Approach:
+    1. At line 707, add one more condition to the AND chain:
+       `&& !(component.id == "customization" && component.scriptName.contains("termux"))`
+    2. Update the explanatory comment above to call out the new
+       exclusion.
+    3. No model changes, no intent changes — UI-only.
+
+    Edge cases:
+    - The same id "customization" exists in debianComponents (Debian
+      path) and termuxComponents (Termux path). The scriptName check
+      scopes the new exclusion to Termux. Debian's behavior is
+      unchanged (still shows button — same T1 ambiguity that user
+      can fix in a separate todo if they want).
+    - If user installs Termux xfce4_desktop, then customisation, the
+      customisation card no longer shows Uninstall. They can still
+      use Re-run. To remove: re-flash Termux prefix (heavy) — same
+      constraint as xfce4_desktop and hw_accel, which are also
+      hidden. Acceptable.
+    - T9 will add `if [ "$1" = "uninstall" ]` branches to
+      setup_customization_termux.sh and the other 4 Termux setup
+      scripts. Once T9 lands, this gate's exclusion can be relaxed
+      in a follow-up PR.
+
+    Test plan:
+    - Build: ./gradlew assembleDebug succeeds.
+    - Manual visual: open Termux distro, install xfce4_desktop + then
+      customization. Expect: customization card has Re-run button
+      but no Uninstall button. xfce4_desktop card has neither
+      (already excluded). hw_accel card has neither (mandatory).
+      kde_plasma + kde_customization cards: still have Uninstall
+      button (they're also broken but user only flagged xfce
+      customisation; T9 will fix all of them).
+    - Manual regression: Debian distro customization card still
+      shows Uninstall button (scriptName doesn't match).
+
+    Open questions: none.
+---
+---

--- a/docs/todo/in-progress.md
+++ b/docs/todo/in-progress.md
@@ -1,1 +1,82 @@
 ---
+- id: T8
+  title: Termux customisation + hardware-accel components missing uninstall button
+  type: bug
+  priority: high
+  difficulty: easy
+  why: User report — xfce customisation has Uninstall button (Debian path works), but Termux customisation and hw_accel components do not. Inconsistent UX across components. Possibly tied to T1 plan: hw_accel is mandatory (T1 explicitly hid button for it), but customisation was skipped per spec — user wants it unhidden.
+  expected: Every non-mandatory component (including xfce4 customisation, kde customisation, hw_accel-if-applicable) shows an Uninstall button in the Termux distro ComponentManagementGlassCard.
+  actual: Termux customisation and hw_accel components do not render the Uninstall button. xfce4 customisation does (Debian path). Inconsistent.
+  reproduction: |
+    1. Open FluxLinux on a Termux distro
+    2. Install a component (e.g., xfce4 customisation or hw_accel)
+    3. Open DistroSettings screen
+    4. Expected: Uninstall button visible next to Re-run
+    5. Actual: button missing for customisation + hw_accel
+  frequency: always
+  impact: DistroSettingsScreen.kt (button visibility logic) — TermuxIntentFactory.kt (intent plumbing) — possibly setup_hw_accel_termux.sh / setup_customization_termux.sh if they lack uninstall branch
+  followups: T9 (add uninstall block to termux component scripts)
+  images: null
+  github_ref: null
+  plan: |
+    Goal: Hide the broken Uninstall button on Termux XFCE4 Customization
+    card. The button is currently visible (id="customization" is not
+    mandatory, not comingSoon, not xfce4_desktop) but tapping it runs
+    `setup_customization_termux.sh uninstall` — the script has no
+    `uninstall` arg branch, so it re-runs the install. Same risk T1
+    noted for xfce4_desktop.
+
+    T8 = UI fix (hide). T9 = add `uninstall` branch to Termux scripts so
+    the button can be re-enabled in a follow-up. Pair stays decoupled
+    per user direction.
+
+    Files to change:
+    - MOD app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/DistroSettingsScreen.kt
+        Add `component.id == "customization" && component.scriptName.contains("termux")`
+        to the gate at line 707 so the button is hidden for the broken
+        case. Scope to Termux only via the scriptName check — the same
+        id ("customization") in Debian will still get the button
+        (Debian's setup_customization_debian.sh also has no uninstall
+        branch, but T1 already excluded it from coverage; if the user
+        wants the Debian path hidden too, that becomes a follow-up).
+        Update the comment block at lines 702-706 to mention
+        "Termux xfce customisation: hidden because its script lacks an
+        uninstall branch (T9 will add it)."
+
+    Approach:
+    1. At line 707, add one more condition to the AND chain:
+       `&& !(component.id == "customization" && component.scriptName.contains("termux"))`
+    2. Update the explanatory comment above to call out the new
+       exclusion.
+    3. No model changes, no intent changes — UI-only.
+
+    Edge cases:
+    - The same id "customization" exists in debianComponents (Debian
+      path) and termuxComponents (Termux path). The scriptName check
+      scopes the new exclusion to Termux. Debian's behavior is
+      unchanged (still shows button — same T1 ambiguity that user
+      can fix in a separate todo if they want).
+    - If user installs Termux xfce4_desktop, then customisation, the
+      customisation card no longer shows Uninstall. They can still
+      use Re-run. To remove: re-flash Termux prefix (heavy) — same
+      constraint as xfce4_desktop and hw_accel, which are also
+      hidden. Acceptable.
+    - T9 will add `if [ "$1" = "uninstall" ]` branches to
+      setup_customization_termux.sh and the other 4 Termux setup
+      scripts. Once T9 lands, this gate's exclusion can be relaxed
+      in a follow-up PR.
+
+    Test plan:
+    - Build: ./gradlew assembleDebug succeeds.
+    - Manual visual: open Termux distro, install xfce4_desktop + then
+      customization. Expect: customization card has Re-run button
+      but no Uninstall button. xfce4_desktop card has neither
+      (already excluded). hw_accel card has neither (mandatory).
+      kde_plasma + kde_customization cards: still have Uninstall
+      button (they're also broken but user only flagged xfce
+      customisation; T9 will fix all of them).
+    - Manual regression: Debian distro customization card still
+      shows Uninstall button (scriptName doesn't match).
+
+    Open questions: none.
+---


### PR DESCRIPTION
Implements T8

## Summary
Hide the broken Uninstall button on the Termux XFCE4 Customization card. Tapping it currently re-runs `setup_customization_termux.sh` (no `uninstall` arg branch → reinstall). Same risk T1 noted for xfce4_desktop.

## Change
- `app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/DistroSettingsScreen.kt:707` — added `!(component.id == "customization" && component.scriptName.contains("termux"))` to the gate. Termux scoped only (same id on Debian unchanged).

## Testing
- `./gradlew assembleDebug` — BUILD SUCCESSFUL
- Manual: installed APK on device, verified Termux customisation card has Re-run only, no Uninstall button.
- kde_plasma + kde_customization still show Uninstall (will be broken until T9 lands).

## Followups
- T9 — add `if [ "$1" = "uninstall" ]` branch to `setup_customization_termux.sh` (and 4 other Termux scripts). Once landed, drop the scriptName exclusion in a follow-up PR to re-enable the button.
