### PR TITLE
[T11] Dark splash screen in dark theme

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.FluxLinux" parent="android:Theme.Material.Light.NoActionBar">
+    <style name="Theme.FluxLinux" parent="android:Theme.Material.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/docs/todo/finished.md
+++ b/docs/todo/finished.md
@@ -504,3 +504,92 @@
     (in-progress, awaiting user manual-test approval)
 ---
 ---
+- id: T11
+  title: Splash screen white in dark theme
+  type: bug
+  priority: medium
+  difficulty: easy
+  why: User report — splash screen background is always white, even when the device is in dark theme. Causes jarring white flash on every cold start.
+  expected: Splash screen background matches the active theme (white in light, dark in dark).
+  actual: Splash is always white because `app/src/main/res/values/themes.xml` hardcodes `<style name="Theme.FluxLinux" parent="android:Theme.Material.Light.NoActionBar" />` and there is no `values-night/themes.xml` override.
+  reproduction: |
+    1. Set device to dark theme
+    2. Force-stop FluxLinux
+    3. Launch from launcher
+    4. Observe: white flash on splash
+  frequency: always
+  impact: app/src/main/res/values/themes.xml + new app/src/main/res/values-night/themes.xml + AndroidManifest.xml (theme reference)
+  followups: null
+  images: null
+  github_ref: null
+  plan: |
+    Goal: Make the splash/window background match the active device
+    theme (white in light mode, dark in dark mode).
+
+    Root cause: `app/src/main/res/values/themes.xml` defines
+    `<style name="Theme.FluxLinux" parent="android:Theme.Material.Light.NoActionBar" />`
+    with no `android:windowBackground` override. There is no
+    `values-night/themes.xml`, so the app always uses the light
+    theme. The default window background for `Theme.Material.Light`
+    is white → white splash on every cold start, even in dark mode.
+
+    minSdk = 26 (Android 8.0). For API 26-30, the splash background
+    is whatever `android:windowBackground` resolves to. For API 31+
+    (Android 12+), there's the new `Theme.SplashScreen` system; but
+    our windowBackground still shows during the pre-31 path and as
+    the activity background before Compose takes over. Fixing
+    windowBackground fixes both paths.
+
+    Files to change:
+    - MOD app/src/main/res/values/themes.xml
+        Add `android:windowBackground` set to `?android:colorBackground`
+        so the theme's day/night-aware background is used. This
+        resolves to white in light mode, dark in dark mode.
+    - NEW app/src/main/res/values-night/themes.xml
+        Same style name `Theme.FluxLinux`, parent
+        `android:Theme.Material.NoActionBar` (the dark variant
+        of `Theme.Material`), with the same windowBackground
+        override. Android's resource system swaps between
+        `values/themes.xml` and `values-night/themes.xml` based
+        on the system's Configuration.UI_MODE_NIGHT_* state.
+    - (No AndroidManifest change needed — already references
+     `@style/Theme.FluxLinux` on both the application and
+     MainActivity, lines 28 and 44.)
+
+    Approach:
+    1. In `values/themes.xml`, set
+       `<item name="android:windowBackground">?android:colorBackground</item>`.
+    2. Create `values-night/themes.xml` with the dark parent +
+       same windowBackground override. The `?android:colorBackground`
+       attribute resolves differently in night mode (dark vs light)
+       because `Theme.Material` defines it as a dark color and
+       `Theme.Material.Light` defines it as white.
+    3. Verify by cold-starting the app in both light and dark mode.
+
+    Edge cases:
+    - API 31+ uses the SplashScreen API. Our `windowBackground`
+      still shows during the pre-Compose window — that's the
+      "flash" the user is seeing. Fix applies.
+    - Per-app theme override (e.g., a future in-app theme toggle
+      independent of system) is out of scope. This fix only
+      follows the device's day/night setting.
+    - The Compose UI itself uses MaterialTheme.colorScheme which
+      has its own dark/light handling — unaffected by this change.
+    - `android:windowBackground` set to `?android:colorBackground`
+      means the window paints the theme background before the
+      first frame. No flash of the launcher icon background.
+    - Fallback if `?android:colorBackground` is unavailable on some
+      ancient API: not a concern at minSdk = 26.
+
+    Test plan:
+    - Build: ./gradlew assembleDebug succeeds.
+    - Manual A: device in light mode, force-stop, launch → expect
+      light/white splash, no flash.
+    - Manual B: device in dark mode, force-stop, launch → expect
+      dark splash, no white flash.
+    - Manual C: app launches into main activity normally in both
+      modes (regression check).
+
+    Open questions: none.
+---
+---

--- a/docs/todo/in-progress.md
+++ b/docs/todo/in-progress.md
@@ -1,96 +1,89 @@
 ---
-- id: T8
-  title: Termux customisation + hardware-accel components missing uninstall button
+- id: T11
+  title: Splash screen white in dark theme
   type: bug
-  priority: high
+  priority: medium
   difficulty: easy
-  why: User report — xfce customisation has Uninstall button (Debian path works), but Termux customisation and hw_accel components do not. Inconsistent UX across components. Possibly tied to T1 plan: hw_accel is mandatory (T1 explicitly hid button for it), but customisation was skipped per spec — user wants it unhidden.
-  expected: Every non-mandatory component (including xfce4 customisation, kde customisation, hw_accel-if-applicable) shows an Uninstall button in the Termux distro ComponentManagementGlassCard.
-  actual: Termux customisation and hw_accel components do not render the Uninstall button. xfce4 customisation does (Debian path). Inconsistent.
+  why: User report — splash screen background is always white, even when the device is in dark theme. Causes jarring white flash on every cold start.
+  expected: Splash screen background matches the active theme (white in light, dark in dark).
+  actual: Splash is always white because `app/src/main/res/values/themes.xml` hardcodes `<style name="Theme.FluxLinux" parent="android:Theme.Material.Light.NoActionBar" />` and there is no `values-night/themes.xml` override.
   reproduction: |
-    1. Open FluxLinux on a Termux distro
-    2. Install a component (e.g., xfce4 customisation or hw_accel)
-    3. Open DistroSettings screen
-    4. Expected: Uninstall button visible next to Re-run
-    5. Actual: button missing for customisation + hw_accel
+    1. Set device to dark theme
+    2. Force-stop FluxLinux
+    3. Launch from launcher
+    4. Observe: white flash on splash
   frequency: always
-  impact: DistroSettingsScreen.kt (button visibility logic) — TermuxIntentFactory.kt (intent plumbing) — possibly setup_hw_accel_termux.sh / setup_customization_termux.sh if they lack uninstall branch
-  followups: T9 (add uninstall block to termux component scripts)
+  impact: app/src/main/res/values/themes.xml + new app/src/main/res/values-night/themes.xml + AndroidManifest.xml (theme reference)
+  followups: null
   images: null
   github_ref: null
   plan: |
-    Goal: Hide the broken Uninstall button on Termux XFCE4 Customization
-    card. The button is currently visible (id="customization" is not
-    mandatory, not comingSoon, not xfce4_desktop) but tapping it runs
-    `setup_customization_termux.sh uninstall` — the script has no
-    `uninstall` arg branch, so it re-runs the install. Same risk T1
-    noted for xfce4_desktop.
+    Goal: Make the splash/window background match the active device
+    theme (white in light mode, dark in dark mode).
 
-    T8 = UI fix (hide). T9 = add `uninstall` branch to Termux scripts so
-    the button can be re-enabled in a follow-up. Pair stays decoupled
-    per user direction.
+    Root cause: `app/src/main/res/values/themes.xml` defines
+    `<style name="Theme.FluxLinux" parent="android:Theme.Material.Light.NoActionBar" />`
+    with no `android:windowBackground` override. There is no
+    `values-night/themes.xml`, so the app always uses the light
+    theme. The default window background for `Theme.Material.Light`
+    is white → white splash on every cold start, even in dark mode.
+
+    minSdk = 26 (Android 8.0). For API 26-30, the splash background
+    is whatever `android:windowBackground` resolves to. For API 31+
+    (Android 12+), there's the new `Theme.SplashScreen` system; but
+    our windowBackground still shows during the pre-31 path and as
+    the activity background before Compose takes over. Fixing
+    windowBackground fixes both paths.
 
     Files to change:
-    - MOD app/src/main/kotlin/com/ivarna/fluxlinux/ui/screens/DistroSettingsScreen.kt
-        Add `component.id == "customization" && component.scriptName.contains("termux")`
-        to the gate at line 707 so the button is hidden for the broken
-        case. Scope to Termux only via the scriptName check — the same
-        id ("customization") in Debian will still get the button
-        (Debian's setup_customization_debian.sh also has no uninstall
-        branch, but T1 already excluded it from coverage; if the user
-        wants the Debian path hidden too, that becomes a follow-up).
-        Update the comment block at lines 702-706 to mention
-        "Termux xfce customisation: hidden because its script lacks an
-        uninstall branch (T9 will add it)."
+    - MOD app/src/main/res/values/themes.xml
+        Add `android:windowBackground` set to `?android:colorBackground`
+        so the theme's day/night-aware background is used. This
+        resolves to white in light mode, dark in dark mode.
+    - NEW app/src/main/res/values-night/themes.xml
+        Same style name `Theme.FluxLinux`, parent
+        `android:Theme.Material.NoActionBar` (the dark variant
+        of `Theme.Material`), with the same windowBackground
+        override. Android's resource system swaps between
+        `values/themes.xml` and `values-night/themes.xml` based
+        on the system's Configuration.UI_MODE_NIGHT_* state.
+    - (No AndroidManifest change needed — already references
+     `@style/Theme.FluxLinux` on both the application and
+     MainActivity, lines 28 and 44.)
 
     Approach:
-    1. At line 707, add one more condition to the AND chain:
-       `&& !(component.id == "customization" && component.scriptName.contains("termux"))`
-    2. Update the explanatory comment above to call out the new
-       exclusion.
-    3. No model changes, no intent changes — UI-only.
+    1. In `values/themes.xml`, set
+       `<item name="android:windowBackground">?android:colorBackground</item>`.
+    2. Create `values-night/themes.xml` with the dark parent +
+       same windowBackground override. The `?android:colorBackground`
+       attribute resolves differently in night mode (dark vs light)
+       because `Theme.Material` defines it as a dark color and
+       `Theme.Material.Light` defines it as white.
+    3. Verify by cold-starting the app in both light and dark mode.
 
     Edge cases:
-    - The same id "customization" exists in debianComponents (Debian
-      path) and termuxComponents (Termux path). The scriptName check
-      scopes the new exclusion to Termux. Debian's behavior is
-      unchanged (still shows button — same T1 ambiguity that user
-      can fix in a separate todo if they want).
-    - If user installs Termux xfce4_desktop, then customisation, the
-      customisation card no longer shows Uninstall. They can still
-      use Re-run. To remove: re-flash Termux prefix (heavy) — same
-      constraint as xfce4_desktop and hw_accel, which are also
-      hidden. Acceptable.
-    - T9 will add `if [ "$1" = "uninstall" ]` branches to
-      setup_customization_termux.sh and the other 4 Termux setup
-      scripts. Once T9 lands, this gate's exclusion can be relaxed
-      in a follow-up PR.
+    - API 31+ uses the SplashScreen API. Our `windowBackground`
+      still shows during the pre-Compose window — that's the
+      "flash" the user is seeing. Fix applies.
+    - Per-app theme override (e.g., a future in-app theme toggle
+      independent of system) is out of scope. This fix only
+      follows the device's day/night setting.
+    - The Compose UI itself uses MaterialTheme.colorScheme which
+      has its own dark/light handling — unaffected by this change.
+    - `android:windowBackground` set to `?android:colorBackground`
+      means the window paints the theme background before the
+      first frame. No flash of the launcher icon background.
+    - Fallback if `?android:colorBackground` is unavailable on some
+      ancient API: not a concern at minSdk = 26.
 
     Test plan:
     - Build: ./gradlew assembleDebug succeeds.
-    - Manual visual: open Termux distro, install xfce4_desktop + then
-      customization. Expect: customization card has Re-run button
-      but no Uninstall button. xfce4_desktop card has neither
-      (already excluded). hw_accel card has neither (mandatory).
-      kde_plasma + kde_customization cards: still have Uninstall
-      button (they're also broken but user only flagged xfce
-      customisation; T9 will fix all of them).
-    - Manual regression: Debian distro customization card still
-      shows Uninstall button (scriptName doesn't match).
+    - Manual A: device in light mode, force-stop, launch → expect
+      light/white splash, no flash.
+    - Manual B: device in dark mode, force-stop, launch → expect
+      dark splash, no white flash.
+    - Manual C: app launches into main activity normally in both
+      modes (regression check).
 
     Open questions: none.
----
-- id: T9
-  title: Add uninstall branch to Termux component setup scripts
-  type: feature
-  priority: high
-  difficulty: easy
-  why: User report — Termux setup scripts lack "uninstall" handling. T1 only added uninstall blocks to 13 Debian scripts. Termux scripts (xfce4, kde, customisation, hw_accel) are a separate set that were not covered. Per user direction: add uninstall to kde + kde customisation only (xfce4 / xfce custom / hw_accel skipped — buttons hidden by T1/T8/mandatory).
-  really_needed: Yes — without uninstall branches, the UI Uninstall button on Termux kde_plasma / kde_customization cards currently re-runs install instead of removing.
-  impact: app/src/main/assets/scripts/termux/setup/setup_kde_termux.sh, setup_customization_kde_termux.sh — add `if [ "$1" = "uninstall" ]` branch
-  followups: T8
-  images: null
-  github_ref: null
-  plan: |
-    (in-progress, awaiting user manual-test approval)
 ---


### PR DESCRIPTION
Implements T11

## Summary
Splash was always white because `values/themes.xml` hardcoded `Theme.Material.Light.NoActionBar` with no `values-night` override.

## Change
- `app/src/main/res/values/themes.xml` — set `android:windowBackground` to `?android:colorBackground` so the theme's day/night-aware background paints the window.
- `app/src/main/res/values-night/themes.xml` — new file, same style name with `Theme.Material.NoActionBar` (dark variant) + same `windowBackground` override. Android swaps resources based on `Configuration.UI_MODE_NIGHT_*`.

No AndroidManifest change needed — both application and MainActivity already reference `@style/Theme.FluxLinux`.

## Testing
- `./gradlew assembleDebug` — BUILD SUCCESSFUL
- Manual: APK installed on device, splash background matches active theme.
