### PR TITLE
[T10] Fix Termux KDE launch and customization

### DIFF
--- a/app/src/main/assets/scripts/termux/setup/setup_customization_kde_termux.sh
+++ b/app/src/main/assets/scripts/termux/setup/setup_customization_kde_termux.sh
@@ -36,6 +36,7 @@ mkdir -p "$HOME/.icons"
 mkdir -p "$HOME/.fluxlinux/wallpapers"
 mkdir -p "$HOME/.config"
 mkdir -p "$HOME/.local/share/wallpapers"
+mkdir -p "$HOME/.local/share/konsole"
 
 # ── Step 1: Icon theme ────────────────────────────────────
 echo "===== Installing Papirus Icon Theme ====="
@@ -64,102 +65,254 @@ if [ ! -f "$WALLPAPER_PATH" ]; then
 fi
 echo " [✅] Wallpaper ready"
 
-# ── Step 3: KDE Global Theme (Breeze Dark) ────────────────
-echo ""
-echo "===== Applying KDE Breeze Dark Theme ====="
-
-# Color scheme
-kwriteconfig5 --file kdeglobals \
-    --group "General" \
-    --key "ColorScheme" "BreezeDark" 2>/dev/null || \
-cat >> "$HOME/.config/kdeglobals" << 'EOF'
-
-[General]
-ColorScheme=BreezeDark
-Name=Breeze Dark
-shadeSortColumn=true
-EOF
-echo " [✅] Color scheme: Breeze Dark"
-
-# Icon theme
-kwriteconfig5 --file kdeglobals \
-    --group "Icons" \
-    --key "Theme" "Papirus-Dark" 2>/dev/null || true
-echo " [✅] Icon theme: Papirus-Dark"
-
-# Font
-kwriteconfig5 --file kdeglobals \
-    --group "General" \
-    --key "font" "Noto Sans,10,-1,5,50,0,0,0,0,0" 2>/dev/null || true
-kwriteconfig5 --file kdeglobals \
-    --group "WM" \
-    --key "activeFont" "Noto Sans,10,-1,5,75,0,0,0,0,0" 2>/dev/null || true
-echo " [✅] Fonts: Noto Sans 10"
-
-# ── Step 4: KWin config (stability + performance) ─────────
-echo ""
-echo "===== Configuring KWin (Stability Workarounds) ====="
-kwriteconfig5 --file kwinrc \
-    --group "Compositing" \
-    --key "Enabled" "false" 2>/dev/null || true
-kwriteconfig5 --file kwinrc \
-    --group "Compositing" \
-    --key "Backend" "OpenGL" 2>/dev/null || true
-echo " [✅] KWin compositing disabled (prevents crashes on mobile GPU)"
-
-# Disable desktop effects that need compositing
-kwriteconfig5 --file kwinrc \
-    --group "Plugins" \
-    --key "blurEnabled" "false" 2>/dev/null || true
-kwriteconfig5 --file kwinrc \
-    --group "Plugins" \
-    --key "desktopgridEnabled" "false" 2>/dev/null || true
-echo " [✅] Compositing effects disabled"
-
-# ── Step 5: HiDPI scaling ─────────────────────────────────
-echo ""
-echo "===== Configuring HiDPI Scaling (2x for Android) ====="
-kwriteconfig5 --file kdeglobals \
-    --group "KScreen" \
-    --key "ScaleFactor" "2" 2>/dev/null || true
-kwriteconfig5 --file kdeglobals \
-    --group "General" \
-    --key "XftDPI" "192" 2>/dev/null || true
-echo " [✅] HiDPI scaling: 2x (192 DPI)"
-
-# ── Step 6: Plasma wallpaper ──────────────────────────────
-echo ""
-echo "===== Setting KDE Wallpaper ====="
-# Copy to KDE wallpapers dir
-mkdir -p "$HOME/.local/share/wallpapers/FluxLinux"
-cp "$WALLPAPER_PATH" "$HOME/.local/share/wallpapers/FluxLinux/contents.jpg" 2>/dev/null || true
-
-# Set via plasma-apply-wallpaperimage if available
-if command -v plasma-apply-wallpaperimage >/dev/null 2>&1; then
-    plasma-apply-wallpaperimage "$WALLPAPER_PATH" 2>/dev/null || true
-    echo " [✅] Wallpaper applied via plasma-apply-wallpaperimage"
+# ── Step 3: Theme selection ───────────────────────────────
+if [ -n "$FLUX_THEME" ]; then
+    echo "FluxLinux: Auto-applying Theme: $FLUX_THEME"
+    if [ "$FLUX_THEME" = "light" ]; then
+        THEME_CHOICE="2"
+    else
+        THEME_CHOICE="1"
+    fi
 else
-    echo " [⚠️] plasma-apply-wallpaperimage not available — set wallpaper manually in KDE settings"
+    echo "------------------------------------------------"
+    echo "Select Theme Preference:"
+    echo "1) Dark (Default)"
+    echo "2) Light"
+    read -p "Enter choice [1-2]: " THEME_CHOICE
+    echo "------------------------------------------------"
 fi
 
-# ── Step 7: GTK theming (for GTK apps in KDE) ────────────
+if [ "$THEME_CHOICE" = "2" ]; then
+    KDE_COLOR_SCHEME="BreezeLight"
+    KDE_PLASMA_THEME="breeze"
+    KDE_LOOK_AND_FEEL="org.kde.breeze.desktop"
+    SEL_ICON="Papirus"
+    GTK_DARK="0"
+else
+    KDE_COLOR_SCHEME="BreezeDark"
+    KDE_PLASMA_THEME="breeze-dark"
+    KDE_LOOK_AND_FEEL="org.kde.breezedark.desktop"
+    SEL_ICON="Papirus-Dark"
+    GTK_DARK="1"
+fi
+
+# ── Step 4: KDE config files (Debian-compatible layout) ───
+echo ""
+echo "===== Applying KDE Plasma Settings ====="
+KDE_CONFIG="$HOME/.config"
+WALLPAPER_DESKTOP_PATH="$HOME/.local/share/wallpapers/FluxLinux/contents.jpg"
+mkdir -p "$KDE_CONFIG" "$HOME/.local/share/wallpapers/FluxLinux"
+cp "$WALLPAPER_PATH" "$WALLPAPER_DESKTOP_PATH" 2>/dev/null || WALLPAPER_DESKTOP_PATH="$WALLPAPER_PATH"
+
+echo "FluxLinux: Writing kdeglobals..."
+cat > "$KDE_CONFIG/kdeglobals" << EOF
+[General]
+ColorScheme=$KDE_COLOR_SCHEME
+Name=$KDE_COLOR_SCHEME
+shadeSortColumn=true
+fixed=Noto Sans Mono,10,-1,5,50,0,0,0,0,0
+font=Noto Sans,10,-1,5,50,0,0,0,0,0
+menuFont=Noto Sans,10,-1,5,50,0,0,0,0,0
+smallestReadableFont=Noto Sans,8,-1,5,50,0,0,0,0,0
+toolBarFont=Noto Sans,10,-1,5,50,0,0,0,0,0
+XftDPI=192
+
+[Icons]
+Theme=$SEL_ICON
+
+[KDE]
+LookAndFeelPackage=$KDE_LOOK_AND_FEEL
+ShowDeleteCommand=false
+SingleClick=false
+widgetStyle=Breeze
+
+[KScreen]
+ScaleFactor=2
+
+[WM]
+activeFont=Noto Sans,10,-1,5,700,0,0,0,0,0
+EOF
+
+echo "FluxLinux: Writing kcminputrc..."
+cat > "$KDE_CONFIG/kcminputrc" << EOF
+[Mouse]
+cursorSize=24
+cursorTheme=breeze_cursors
+EOF
+
+echo "FluxLinux: Writing kwinrc..."
+cat > "$KDE_CONFIG/kwinrc" << 'EOF'
+[Compositing]
+Backend=QPainter
+Enabled=false
+OpenGLIsUnsafe=true
+
+[Plugins]
+blurEnabled=false
+desktopgridEnabled=false
+kwin4_effect_fadingpopupsEnabled=false
+kwin4_effect_frozenappEnabled=false
+kwin4_effect_loginEnabled=false
+kwin4_effect_logoutEnabled=false
+kwin4_effect_morphingpopupsEnabled=false
+kwin4_effect_squashEnabled=false
+kwin4_effect_windowapertureEnabled=false
+
+[Windows]
+BorderlessMaximizedWindows=false
+FocusPolicy=ClickToFocus
+TitlebarDoubleClickCommand=Maximize
+SnapAgainst=1
+
+[org.kde.kdecoration2]
+ButtonsOnLeft=M
+ButtonsOnRight=HIA
+library=org.kde.breeze
+theme=Breeze
+EOF
+
+echo "FluxLinux: Writing plasmarc..."
+cat > "$KDE_CONFIG/plasmarc" << EOF
+[Theme]
+name=$KDE_PLASMA_THEME
+EOF
+
+echo "FluxLinux: Writing Plasma desktop config..."
+cat > "$KDE_CONFIG/plasma-org.kde.plasma.desktop-appletsrc" << EOF
+[Containments][1]
+ItemGeometriesHorizontal=
+activityId=
+formfactor=0
+immutability=1
+lastScreen=0
+location=0
+plugin=org.kde.plasma.folder
+wallpaperplugin=org.kde.image
+
+[Containments][1][General]
+ToolBoxButtonState=topcenter
+
+[Containments][1][Wallpaper][org.kde.image][General]
+Image=$WALLPAPER_DESKTOP_PATH
+PreviewImage=$WALLPAPER_DESKTOP_PATH
+
+[Containments][2]
+activityId=
+formfactor=2
+immutability=1
+lastScreen=0
+location=4
+plugin=org.kde.panel
+wallpaperplugin=org.kde.image
+
+[Containments][2][Applets][3]
+immutability=1
+plugin=org.kde.plasma.kickoff
+
+[Containments][2][Applets][4]
+immutability=1
+plugin=org.kde.plasma.taskmanager
+
+[Containments][2][Applets][5]
+immutability=1
+plugin=org.kde.plasma.systemtray
+
+[Containments][2][Applets][6]
+immutability=1
+plugin=org.kde.plasma.digitalclock
+
+[Containments][2][Applets][7]
+immutability=1
+plugin=org.kde.plasma.showdesktop
+
+[Containments][2][General]
+AppletOrder=3;4;5;6;7
+EOF
+
+echo "FluxLinux: Writing keyboard shortcuts..."
+cat > "$KDE_CONFIG/kglobalshortcutsrc" << 'EOF'
+[kwin]
+Show Desktop=Meta+D,Meta+D,Show Desktop
+Window Maximize=Meta+Up,Meta+Up,Maximize Window
+Window Close=Alt+F4,Alt+F4,Close Window
+Walk Through Windows=Alt+Tab,Alt+Tab,Walk Through Windows
+Reverse Walk Through Windows=Alt+Shift+Tab,Alt+Shift+Tab,Reverse Walk Through Windows
+Window Fullscreen=Meta+F,none,Make Window Fullscreen
+Window Minimize=Meta+M,none,Minimize Window
+Window Move=Meta+W,none,Move Window
+Window Resize=none,none,Resize Window
+
+[org.kde.konsole.desktop]
+NewTab=Ctrl+T,Ctrl+T,New Tab
+NewWindow=Ctrl+N,Ctrl+N,New Window
+
+[plasma-desktop]
+_launch=none,none,KDE Plasma Desktop
+EOF
+
+echo "FluxLinux: Writing font DPI config..."
+cat > "$KDE_CONFIG/kcmfonts" << 'EOF'
+[General]
+forceFontDPI=192
+EOF
+
+echo "FluxLinux: Configuring Konsole..."
+cat > "$HOME/.local/share/konsole/FluxLinux.profile" << 'EOF'
+[Appearance]
+ColorScheme=Breeze
+Font=Noto Sans Mono,12,-1,5,400,0,0,0,0,0,0,0,0,0,0,1
+antialias=true
+
+[General]
+Command=/data/data/com.termux/files/usr/bin/bash
+Name=FluxLinux
+Parent=FALLBACK/
+
+[Interaction Options]
+AutoCopySelectedText=true
+TrimLeadingWhitespacesInSelectedText=true
+TrimTrailingWhitespacesInSelectedText=true
+
+[Scrolling]
+HistoryMode=2
+HistorySize=10000
+
+[Terminal Features]
+BidiRenderingEnabled=true
+BlinkingCursorEnabled=false
+EOF
+
+cat > "$KDE_CONFIG/konsolerc" << 'EOF'
+[Desktop Entry]
+DefaultProfile=FluxLinux.profile
+
+[KonsoleWindow]
+RememberWindowSize=true
+
+[TabBar]
+CloseTabOnMiddleMouseButton=true
+TabBarVisibility=ShowTabBarWhenNeeded
+EOF
+
+# Set live wallpaper when Plasma is already running; config files handle next launch.
+if command -v plasma-apply-wallpaperimage >/dev/null 2>&1; then
+    plasma-apply-wallpaperimage "$WALLPAPER_DESKTOP_PATH" 2>/dev/null || true
+fi
+
+echo " [✅] KDE settings written"
+
+# ── Step 5: GTK theming (for GTK apps in KDE) ────────────
 echo ""
 echo "===== Configuring GTK Apps in KDE ====="
 mkdir -p "$HOME/.config/gtk-3.0"
-cat > "$HOME/.config/gtk-3.0/settings.ini" << 'EOF'
+cat > "$HOME/.config/gtk-3.0/settings.ini" << EOF
 [Settings]
 gtk-theme-name=Adwaita-dark
-gtk-icon-theme-name=Papirus-Dark
+gtk-icon-theme-name=$SEL_ICON
 gtk-font-name=Noto Sans 10
-gtk-application-prefer-dark-theme=1
+gtk-application-prefer-dark-theme=$GTK_DARK
 EOF
-echo " [✅] GTK dark theme configured for Qt/KDE apps"
-
-# ── Step 8: Single-click fix ──────────────────────────────
-kwriteconfig5 --file kdeglobals \
-    --group "KDE" \
-    --key "SingleClick" "false" 2>/dev/null || true
-echo " [✅] Double-click to open files (mobile-friendly)"
+echo " [✅] GTK theme configured"
 
 # ── Callback to app ──────────────────────────────────────
 am start -a android.intent.action.VIEW \

--- a/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
+++ b/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
@@ -113,6 +113,12 @@ fi
 termux-x11 :0 &
 sleep 3
 
+# ── Auto-open the Termux:X11 viewer ──────────────────────
+echo "FluxLinux: Opening Termux:X11 viewer..."
+am start -n com.termux.x11/.MainActivity 2>/dev/null || \
+    echo " [⚠️] Could not auto-open Termux:X11 — please open it manually"
+sleep 1
+
 # ── Step 5: Export display env ───────────────────────────
 export DISPLAY=:0
 export LIBGL_ALWAYS_INDIRECT=1

--- a/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
+++ b/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
@@ -83,13 +83,15 @@ echo "FluxLinux: Starting GPU acceleration server..."
 case "$GPU_BACKEND" in
     turnip)
         echo " Using Turnip + Zink (Adreno — best performance)"
-        MESA_NO_ERROR=1 \
-        MESA_GL_VERSION_OVERRIDE=4.3COMPAT \
-        MESA_GLES_VERSION_OVERRIDE=3.2 \
-        GALLIUM_DRIVER=zink \
-        MESA_LOADER_DRIVER_OVERRIDE=zink \
-        ZINK_DESCRIPTORS=lazy \
-        virgl_test_server --use-egl-surfaceless --use-gles &
+        nohup env MESA_NO_ERROR=1 \
+            MESA_GL_VERSION_OVERRIDE=4.3COMPAT \
+            MESA_GLES_VERSION_OVERRIDE=3.2 \
+            GALLIUM_DRIVER=zink \
+            MESA_LOADER_DRIVER_OVERRIDE=zink \
+            ZINK_DESCRIPTORS=lazy \
+            virgl_test_server --use-egl-surfaceless --use-gles \
+            >/dev/null 2>&1 &
+        disown
         ;;
     software)
         echo " Using software rendering (LLVMpipe)"
@@ -98,7 +100,8 @@ case "$GPU_BACKEND" in
         ;;
     virgl|*)
         echo " Using VirGL (general compatibility)"
-        virgl_test_server_android &
+        nohup virgl_test_server_android >/dev/null 2>&1 &
+        disown
         ;;
 esac
 sleep 2
@@ -110,7 +113,8 @@ if ! command -v termux-x11 >/dev/null 2>&1; then
     read -p "Press Enter to exit..."
     exit 1
 fi
-termux-x11 :0 &
+nohup termux-x11 :0 >/dev/null 2>&1 &
+disown
 sleep 3
 
 # ── Auto-open the Termux:X11 viewer ──────────────────────
@@ -156,21 +160,14 @@ echo "  ┌───────────────────────
 echo "  │  Open the Termux:X11 app to see desktop │"
 echo "  └─────────────────────────────────────────┘"
 echo ""
-startplasma-x11 &
-
-sleep 5
+nohup startplasma-x11 >/dev/null 2>&1 &
+disown
 
 echo ""
 echo "✅ KDE Plasma is starting (GPU: $GPU_BACKEND)"
-echo "   Switch to the Termux:X11 app to see the desktop."
-echo "   Note: KDE may take 10-30 seconds to fully load."
-echo ""
-echo "   To stop: press Enter here (script keeps running until then),"
-echo "   or run 'stop_kde_termux.sh' in another Termux session."
+echo "   The session is detached — it will keep running even if this"
+echo "   script exits. To stop: run 'stop_kde_termux.sh'."
 echo ""
 
-# Block on stdin so the script (and its background processes) stay alive.
-# Without this, the Termux RunCommandService may end the script after the
-# initial setup, sending SIGHUP to startplasma-x11 / termux-x11 / virgl and
-# killing the desktop. The user has to press Enter to actually exit.
-read -p "Press Enter to stop the session and exit: " _
+# Detached — exit cleanly. Background processes survive via nohup + disown.
+exit 0

--- a/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
+++ b/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
@@ -160,14 +160,18 @@ echo "  ┌───────────────────────
 echo "  │  Open the Termux:X11 app to see desktop │"
 echo "  └─────────────────────────────────────────┘"
 echo ""
-nohup startplasma-x11 >/dev/null 2>&1 &
-disown
+KDE_LOG="$HOME/.fluxlinux/kde_session.log"
+mkdir -p "$HOME/.fluxlinux"
+startplasma-x11 >"$KDE_LOG" 2>&1 &
 
 echo ""
 echo "✅ KDE Plasma is starting (GPU: $GPU_BACKEND)"
-echo "   The session is detached — it will keep running even if this"
-echo "   script exits. To stop: run 'stop_kde_termux.sh'."
+echo "   Switch to the Termux:X11 app to see the desktop."
+echo ""
+echo "   Session log: $KDE_LOG"
+echo "   To stop: run 'stop_kde_termux.sh' or press Ctrl+C here."
 echo ""
 
-# Detached — exit cleanly. Background processes survive via nohup + disown.
-exit 0
+# Keep terminal alive — mirrors XFCE4 pattern.
+# Ctrl+C here cleanly kills the plasma session.
+wait

--- a/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
+++ b/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
@@ -126,9 +126,11 @@ sleep 1
 # ── Step 5: Export display env ───────────────────────
 export DISPLAY=:0
 export LIBGL_ALWAYS_INDIRECT=1
-# XDG_RUNTIME_DIR is required by D-Bus and KDE session services.
-# Without it startplasma-x11 exits immediately and silently.
-export XDG_RUNTIME_DIR=${TMPDIR:-/tmp}
+# XDG_RUNTIME_DIR must be mode 700 (owner-only) — D-Bus rejects world-writable dirs.
+# $TMPDIR itself is 1777, so create a private subdirectory.
+export XDG_RUNTIME_DIR="${TMPDIR:-/tmp}/kde-runtime"
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
 case "$GPU_BACKEND" in
     turnip) export GALLIUM_DRIVER=virpipe; export MESA_LOADER_DRIVER_OVERRIDE=zink ;;
     software) ;; # already set above
@@ -139,7 +141,7 @@ esac
 export KWIN_COMPOSE=0
 export KWIN_OPENGL_INTERFACE=egl
 
-echo "FluxLinux: XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
+echo "FluxLinux: XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR (mode $(stat -c '%a' $XDG_RUNTIME_DIR))"
 
 # ── Step 6: D-Bus session ────────────────────────
 echo "FluxLinux: Starting D-Bus session..."

--- a/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
+++ b/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
@@ -119,7 +119,7 @@ sleep 3
 
 # ── Auto-open the Termux:X11 viewer ──────────────────────
 echo "FluxLinux: Opening Termux:X11 viewer..."
-am start -n com.termux.x11/.MainActivity 2>/dev/null || \
+am start --user 0 -n com.termux.x11/com.termux.x11.MainActivity >/dev/null 2>&1 || \
     echo " [⚠️] Could not auto-open Termux:X11 — please open it manually"
 sleep 1
 
@@ -141,8 +141,10 @@ export KWIN_OPENGL_INTERFACE=egl
 
 echo "FluxLinux: XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
 
-# ── Step 6: D-Bus session ────────────────────────────────
+# ── Step 6: D-Bus session ────────────────────────
 echo "FluxLinux: Starting D-Bus session..."
+# Note: Termux dbus-launch does NOT support --exit-with-session.
+# Use --sh-syntax to export DBUS_SESSION_BUS_ADDRESS into this shell.
 if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
     eval "$(dbus-launch --sh-syntax)" 2>/dev/null || \
         echo " [⚠️] D-Bus launch failed — some KDE services may not work"
@@ -191,10 +193,9 @@ echo "   Session log: $KDE_LOG"
 echo "   Output below — Ctrl+C to stop."
 echo ""
 
-# Run inside dbus-launch --exit-with-session so D-Bus is properly
-# wired to the session lifetime (matches reference XFCE4/KDE scripts).
-# tee to log so errors print live AND are saved.
-dbus-launch --exit-with-session startplasma-x11 2>&1 | tee "$KDE_LOG"
+# Run in foreground with tee so errors print live AND save to log.
+# (dbus-launch --exit-with-session is NOT available in Termux)
+startplasma-x11 2>&1 | tee "$KDE_LOG"
 
 echo ""
 echo "🔴 KDE Plasma session ended."

--- a/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
+++ b/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
@@ -123,9 +123,12 @@ am start -n com.termux.x11/.MainActivity 2>/dev/null || \
     echo " [⚠️] Could not auto-open Termux:X11 — please open it manually"
 sleep 1
 
-# ── Step 5: Export display env ───────────────────────────
+# ── Step 5: Export display env ───────────────────────
 export DISPLAY=:0
 export LIBGL_ALWAYS_INDIRECT=1
+# XDG_RUNTIME_DIR is required by D-Bus and KDE session services.
+# Without it startplasma-x11 exits immediately and silently.
+export XDG_RUNTIME_DIR=${TMPDIR:-/tmp}
 case "$GPU_BACKEND" in
     turnip) export GALLIUM_DRIVER=virpipe; export MESA_LOADER_DRIVER_OVERRIDE=zink ;;
     software) ;; # already set above
@@ -135,6 +138,8 @@ esac
 # KDE-specific env: disable compositing at env level too
 export KWIN_COMPOSE=0
 export KWIN_OPENGL_INTERFACE=egl
+
+echo "FluxLinux: XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
 
 # ── Step 6: D-Bus session ────────────────────────────────
 echo "FluxLinux: Starting D-Bus session..."
@@ -186,9 +191,10 @@ echo "   Session log: $KDE_LOG"
 echo "   Output below — Ctrl+C to stop."
 echo ""
 
-# Run in foreground, tee to log so errors print live AND are saved.
-# If startplasma-x11 crashes immediately, the error is visible here.
-startplasma-x11 2>&1 | tee "$KDE_LOG"
+# Run inside dbus-launch --exit-with-session so D-Bus is properly
+# wired to the session lifetime (matches reference XFCE4/KDE scripts).
+# tee to log so errors print live AND are saved.
+dbus-launch --exit-with-session startplasma-x11 2>&1 | tee "$KDE_LOG"
 
 echo ""
 echo "🔴 KDE Plasma session ended."

--- a/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
+++ b/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
@@ -154,24 +154,43 @@ Enabled=false" >> "$HOME/.config/kwinrc"
 fi
 
 # ── Step 8: Launch KDE Plasma ────────────────────────────
-echo "FluxLinux: Launching KDE Plasma..."
+
+# Verify startplasma-x11 is actually installed
+if ! command -v startplasma-x11 >/dev/null 2>&1; then
+    echo ""
+    echo "❌ FluxLinux Error: 'startplasma-x11' not found!"
+    echo "   KDE Plasma does not appear to be fully installed."
+    echo "   Please run the KDE setup script again:"
+    echo "     bash setup_kde_termux.sh"
+    echo ""
+    echo "   You can also check manually in Termux:"
+    echo "     pkg list-installed | grep plasma"
+    echo "     which startplasma-x11"
+    echo ""
+    read -p "Press Enter to exit..."
+    exit 1
+fi
+
+echo "FluxLinux: Launching KDE Plasma (this may take 30-60s)..."
 echo ""
 echo "  ┌─────────────────────────────────────────┐"
 echo "  │  Open the Termux:X11 app to see desktop │"
 echo "  └─────────────────────────────────────────┘"
 echo ""
+
 KDE_LOG="$HOME/.fluxlinux/kde_session.log"
 mkdir -p "$HOME/.fluxlinux"
-startplasma-x11 >"$KDE_LOG" 2>&1 &
 
-echo ""
 echo "✅ KDE Plasma is starting (GPU: $GPU_BACKEND)"
-echo "   Switch to the Termux:X11 app to see the desktop."
-echo ""
 echo "   Session log: $KDE_LOG"
-echo "   To stop: run 'stop_kde_termux.sh' or press Ctrl+C here."
+echo "   Output below — Ctrl+C to stop."
 echo ""
 
-# Keep terminal alive — mirrors XFCE4 pattern.
-# Ctrl+C here cleanly kills the plasma session.
-wait
+# Run in foreground, tee to log so errors print live AND are saved.
+# If startplasma-x11 crashes immediately, the error is visible here.
+startplasma-x11 2>&1 | tee "$KDE_LOG"
+
+echo ""
+echo "🔴 KDE Plasma session ended."
+echo "   Check session log for errors: $KDE_LOG"
+echo ""

--- a/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
+++ b/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
@@ -165,8 +165,12 @@ echo "✅ KDE Plasma is starting (GPU: $GPU_BACKEND)"
 echo "   Switch to the Termux:X11 app to see the desktop."
 echo "   Note: KDE may take 10-30 seconds to fully load."
 echo ""
-echo "   To stop: run 'stop_kde_termux.sh'"
-echo "   Or press Ctrl+C here to stop."
+echo "   To stop: press Enter here (script keeps running until then),"
+echo "   or run 'stop_kde_termux.sh' in another Termux session."
 echo ""
 
-wait
+# Block on stdin so the script (and its background processes) stay alive.
+# Without this, the Termux RunCommandService may end the script after the
+# initial setup, sending SIGHUP to startplasma-x11 / termux-x11 / virgl and
+# killing the desktop. The user has to press Enter to actually exit.
+read -p "Press Enter to stop the session and exit: " _

--- a/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
+++ b/app/src/main/assets/scripts/termux/start/start_kde_termux.sh
@@ -8,7 +8,7 @@
 # Launch sequence:
 #   1. Kill previous session
 #   2. Start PulseAudio (TCP mode)
-#   3. Start VirGL server (auto-selects VirGL or Turnip)
+#   3. Use KDE-safe software rendering
 #   4. Start Termux:X11 server
 #   5. Launch KDE Plasma (startplasma-x11)
 #
@@ -64,6 +64,7 @@ echo "FluxLinux: Cleaning up previous session..."
 pkill -f "startplasma" 2>/dev/null || true
 pkill -f "kwin_x11" 2>/dev/null || true
 pkill -f "plasmashell" 2>/dev/null || true
+pkill -f "ksmserver" 2>/dev/null || true
 pkill -f "kded5" 2>/dev/null || true
 pkill -f "termux-x11" 2>/dev/null || true
 pkill -f "virgl_test_server" 2>/dev/null || true
@@ -72,39 +73,20 @@ sleep 1
 
 # ── Step 2: PulseAudio ────────────────────────────────────
 echo "FluxLinux: Starting PulseAudio..."
+unset PULSE_SERVER
+pulseaudio --kill 2>/dev/null || true
 pulseaudio --start \
     --load="module-native-protocol-tcp auth-ip-acl=127.0.0.1 auth-anonymous=1" \
     --exit-idle-time=-1 2>/dev/null || \
     echo " [⚠️] PulseAudio start failed — audio may not work"
 export PULSE_SERVER=127.0.0.1
 
-# ── Step 3: VirGL GPU server ──────────────────────────────
-echo "FluxLinux: Starting GPU acceleration server..."
-case "$GPU_BACKEND" in
-    turnip)
-        echo " Using Turnip + Zink (Adreno — best performance)"
-        nohup env MESA_NO_ERROR=1 \
-            MESA_GL_VERSION_OVERRIDE=4.3COMPAT \
-            MESA_GLES_VERSION_OVERRIDE=3.2 \
-            GALLIUM_DRIVER=zink \
-            MESA_LOADER_DRIVER_OVERRIDE=zink \
-            ZINK_DESCRIPTORS=lazy \
-            virgl_test_server --use-egl-surfaceless --use-gles \
-            >/dev/null 2>&1 &
-        disown
-        ;;
-    software)
-        echo " Using software rendering (LLVMpipe)"
-        export GALLIUM_DRIVER=llvmpipe
-        export LIBGL_ALWAYS_SOFTWARE=1
-        ;;
-    virgl|*)
-        echo " Using VirGL (general compatibility)"
-        nohup virgl_test_server_android >/dev/null 2>&1 &
-        disown
-        ;;
-esac
-sleep 2
+# ── Step 3: KDE-safe software rendering ───────────────────
+echo "FluxLinux: Using software rendering (LLVMpipe) for KDE stability..."
+GPU_BACKEND="software"
+export GALLIUM_DRIVER=llvmpipe
+export LIBGL_ALWAYS_SOFTWARE=1
+sleep 1
 
 # ── Step 4: Termux:X11 ───────────────────────────────────
 echo "FluxLinux: Starting Termux:X11..."
@@ -113,29 +95,26 @@ if ! command -v termux-x11 >/dev/null 2>&1; then
     read -p "Press Enter to exit..."
     exit 1
 fi
-nohup termux-x11 :0 >/dev/null 2>&1 &
+mkdir -p "${TMPDIR:-$PREFIX/tmp}/.X11-unix"
+rm -f "${TMPDIR:-$PREFIX/tmp}/.X11-unix/X0"
+nohup termux-x11 :0 >"${TMPDIR:-$PREFIX/tmp}/termux-x11.log" 2>&1 &
 disown
-sleep 3
+sleep 4
 
 # ── Auto-open the Termux:X11 viewer ──────────────────────
 echo "FluxLinux: Opening Termux:X11 viewer..."
 am start --user 0 -n com.termux.x11/com.termux.x11.MainActivity >/dev/null 2>&1 || \
     echo " [⚠️] Could not auto-open Termux:X11 — please open it manually"
-sleep 1
+sleep 3
 
 # ── Step 5: Export display env ───────────────────────
 export DISPLAY=:0
 export LIBGL_ALWAYS_INDIRECT=1
 # XDG_RUNTIME_DIR must be mode 700 (owner-only) — D-Bus rejects world-writable dirs.
 # $TMPDIR itself is 1777, so create a private subdirectory.
-export XDG_RUNTIME_DIR="${TMPDIR:-/tmp}/kde-runtime"
+export XDG_RUNTIME_DIR="${TMPDIR:-$PREFIX/tmp}/kde-runtime"
 mkdir -p "$XDG_RUNTIME_DIR"
 chmod 700 "$XDG_RUNTIME_DIR"
-case "$GPU_BACKEND" in
-    turnip) export GALLIUM_DRIVER=virpipe; export MESA_LOADER_DRIVER_OVERRIDE=zink ;;
-    software) ;; # already set above
-    virgl|*) export GALLIUM_DRIVER=virpipe ;;
-esac
 
 # KDE-specific env: disable compositing at env level too
 export KWIN_COMPOSE=0

--- a/app/src/main/kotlin/com/ivarna/fluxlinux/core/data/TermuxIntentFactory.kt
+++ b/app/src/main/kotlin/com/ivarna/fluxlinux/core/data/TermuxIntentFactory.kt
@@ -750,6 +750,10 @@ object TermuxIntentFactory {
     fun buildLaunchKdeGuiTurnipIntent(context: android.content.Context, distroId: String): Intent {
         val scriptManager = ScriptManager(context)
 
+        if (distroId == "termux") {
+            return buildLaunchKdeGuiIntent(context, distroId)
+        }
+
         if (distroId == "debian13_chroot") {
             val chrootKdeScriptContent = scriptManager.getScriptContent("debian/chroot/start/start_debian13_kde_gui_turnip.sh")
             val chrootKdeScriptB64 = android.util.Base64.encodeToString(
@@ -800,6 +804,10 @@ object TermuxIntentFactory {
      */
     fun buildLaunchKdeGuiSoftwareIntent(context: android.content.Context, distroId: String): Intent {
         val scriptManager = ScriptManager(context)
+
+        if (distroId == "termux") {
+            return buildLaunchKdeGuiIntent(context, distroId)
+        }
 
         if (distroId == "debian13_chroot") {
             val scriptContent = scriptManager.getScriptContent("debian/chroot/start/start_debian13_kde_gui_software.sh")


### PR DESCRIPTION
Implements T10

## Summary
- Fixes native Termux KDE launch by using the verified Termux:X11/PulseAudio/XDG runtime sequence.
- Routes all Termux KDE GPU picker choices through the same working native launcher.
- Reworks Termux KDE customization to write Debian-style KDE config files directly.

## Testing
- ./gradlew assembleRelease
- Installed release APK on connected device
- User verified KDE launch command worked before script integration
