### PR TITLE
[T7] Add Office Suite stack to Ubuntu

### DIFF
--- a/app/src/main/assets/scripts/ubuntu/common/setup/setup_office_ubuntu.sh
+++ b/app/src/main/assets/scripts/ubuntu/common/setup/setup_office_ubuntu.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+# setup_office_ubuntu.sh
+# Installs Office Productivity Stack
+# Target: Ubuntu 26.04 LTS (Resolute) ARM64
+# Compatible with: Chroot and Proot
+# Usage: setup_office_ubuntu.sh [uninstall]
+#
+# Ubuntu is Debian-LIKE, not Debian: repos stay on ports.ubuntu.com, never
+# add debian.org, PPAs, or ubuntu-desktop. Office packages live in universe,
+# which the base rootfs does not enable.
+
+# Office-specific packages. Shared system deps (dbus-x11, fonts) intentionally
+# excluded — they're used by XFCE, browsers, and other components.
+PKGS=(
+    libreoffice
+    libreoffice-gtk3
+    libreoffice-writer
+    libreoffice-calc
+    libreoffice-impress
+    thunderbird
+    evince
+    papers
+    xournalpp
+    fonts-noto
+)
+
+# ─── UNINSTALL MODE ──────────────────────────────────────────────────────
+if [ "$1" = "uninstall" ]; then
+    echo "FluxLinux: Uninstalling Office Productivity Environment..."
+
+    export DEBIAN_FRONTEND=noninteractive
+    apt remove -y --purge "${PKGS[@]}" 2>/dev/null || true
+    apt autoremove -y 2>/dev/null || true
+
+    echo "FluxLinux: Office Productivity Environment Uninstalled."
+    exit 0
+fi
+# ─── END UNINSTALL MODE ──────────────────────────────────────────────────
+
+# Error Handler
+handle_error() {
+    echo ""
+    echo "❌ FluxLinux Error: Script failed at step: $1"
+    echo "---------------------------------------------------"
+    echo "Please check the error message above for details."
+    echo "---------------------------------------------------"
+    read -p "Press Enter to acknowledge error and exit..."
+    exit 1
+}
+
+echo "FluxLinux: Setting up Office Productivity Environment..."
+echo "Target: Ubuntu 26.04 LTS (Resolute) - ARM64"
+
+# 0. Enable universe (thunderbird, xournalpp, npm and fonts-noto live there).
+# The 26.04 rootfs ships DEB822 ubuntu.sources with main/restricted only.
+# Rewrite in place — never append a new archive.ubuntu.com or PPA entry.
+enable_universe() {
+    echo "FluxLinux: Ensuring 'universe' component is enabled..."
+    _changed=0
+
+    # DEB822 (/etc/apt/sources.list.d/*.sources)
+    for f in /etc/apt/sources.list.d/*.sources; do
+        [ -f "$f" ] || continue
+        grep -q '^Components:' "$f" || continue
+        grep -qE '^Components:.*\buniverse\b' "$f" && continue
+        _tmp="${f}.fluxnew.$$"
+        sed -e 's|^\(Components:.*\)$|\1 universe|' "$f" > "$_tmp" \
+            && mv -f "$_tmp" "$f" && _changed=1
+    done
+
+    # Legacy one-line format (/etc/apt/sources.list)
+    if [ -f /etc/apt/sources.list ] && \
+       grep -qE '^deb .*ports\.ubuntu\.com' /etc/apt/sources.list && \
+       ! grep -qE '^deb .*ports\.ubuntu\.com.* universe' /etc/apt/sources.list; then
+        _tmp="/etc/apt/sources.list.fluxnew.$$"
+        sed -e '/^deb .*ports\.ubuntu\.com/ s|$| universe|' /etc/apt/sources.list > "$_tmp" \
+            && mv -f "$_tmp" /etc/apt/sources.list && _changed=1
+    fi
+
+    [ "$_changed" -eq 1 ] && echo " [✅] universe enabled" || echo " [ℹ️] universe already present"
+}
+
+# 1. System Dependencies
+echo "FluxLinux: Installing Dependencies..."
+export DEBIAN_FRONTEND=noninteractive
+enable_universe
+apt update -y
+
+# Install essential fonts first (these are small and reliable)
+apt install -y \
+    dbus-x11 \
+    fonts-noto-core \
+    fonts-liberation \
+    fonts-dejavu \
+    || handle_error "Dependencies & Fonts"
+
+# Conditional NPM Install (Fix for NodeSource Conflict)
+# If setup_webdev_ubuntu.sh ran, nodejs includes npm.
+# If not, Ubuntu split packages might need explicit npm.
+if ! command -v npm >/dev/null; then
+    echo "FluxLinux: NPM not found (bundled), installing explicitly..."
+    apt install -y npm || echo " [⚠️] NPM install warning (might be bundled)"
+fi
+
+# 2. LibreOffice Suite
+echo "FluxLinux: Installing LibreOffice Suite..."
+# Use --no-install-recommends to avoid large optional packages like fonts-noto-extra
+# which can fail in proot environments due to resource constraints
+apt install -y --no-install-recommends \
+    libreoffice \
+    libreoffice-gtk3 \
+    || {
+        echo "⚠️ LibreOffice install had issues, attempting to fix..."
+        # Fix any broken packages (common in proot with large fonts)
+        apt --fix-broken install -y
+        dpkg --configure -a
+        # Retry with just the core package
+        apt install -y --no-install-recommends libreoffice-writer libreoffice-calc libreoffice-impress libreoffice-gtk3 \
+            || handle_error "LibreOffice Installation"
+    }
+
+# 3. Email & PIM
+echo "FluxLinux: Installing Email & Organization Tools..."
+# Ubuntu ships thunderbird as a snap transitional deb (24.04+). snapd cannot
+# run under proot and is pointless in chroot, so install only the real deb.
+# Non-fatal: mail is optional, LibreOffice is the headline of this stack.
+if apt-cache depends thunderbird 2>/dev/null | grep -qE 'Depends:[[:space:]]*snapd'; then
+    echo " [⚠️] thunderbird in this release is a snap transitional package — skipped."
+    echo "      Install a real deb manually if you need it (no PPAs)."
+else
+    apt install -y --no-install-recommends thunderbird \
+        || echo " [⚠️] Thunderbird not installed (universe/mirror issue)."
+fi
+
+# 4. PDF Tools
+echo "FluxLinux: Installing PDF Tools..."
+# GNOME renamed Evince to Papers; 26.04 may ship either (evince can be a
+# transitional shim). Try evince, fall back to papers, then xournalpp.
+# Non-fatal: LibreOffice can open PDFs anyway.
+if ! apt install -y --no-install-recommends evince 2>/dev/null; then
+    apt --fix-broken install -y 2>/dev/null || true
+    dpkg --configure -a 2>/dev/null || true
+    apt install -y --no-install-recommends papers 2>/dev/null || \
+        echo " [⚠️] No PDF viewer installed (evince/papers unavailable). LibreOffice can still open PDFs."
+fi
+
+apt install -y --no-install-recommends xournalpp 2>/dev/null || \
+    echo " [⚠️] xournalpp not installed (check that universe is enabled)."
+
+# 5. Optional: Try to install extra fonts (non-fatal if fails)
+echo "FluxLinux: Installing additional fonts (optional)..."
+apt install -y fonts-noto 2>/dev/null || echo " [⚠️] Optional fonts skipped (proot limitation)"
+
+# 6. Verification
+verify_installation() {
+    echo ""
+    echo "🔎 FluxLinux: Verifying Installations..."
+    echo "------------------------------------------------"
+
+    if command -v libreoffice >/dev/null; then echo " [✅] LibreOffice"; else echo " [❌] LibreOffice Missing"; fi
+    if command -v thunderbird >/dev/null; then echo " [✅] Thunderbird"; else echo " [⚠️] Thunderbird Skipped"; fi
+    if command -v evince >/dev/null; then
+        echo " [✅] Evince"
+    elif command -v papers >/dev/null; then
+        echo " [✅] Papers"
+    else
+        echo " [⚠️] PDF Viewer Missing"
+    fi
+    if command -v xournalpp >/dev/null; then echo " [✅] Xournal++"; else echo " [❌] Xournal++ Missing"; fi
+
+    echo "------------------------------------------------"
+    echo "🎉 Office Setup Complete!"
+}
+
+verify_installation
+
+echo "Note: Check your Applications menu for installed tools."
+read -p "Press Enter to close..."

--- a/app/src/main/assets/scripts/ubuntu/common/setup/setup_office_ubuntu.sh
+++ b/app/src/main/assets/scripts/ubuntu/common/setup/setup_office_ubuntu.sh
@@ -18,8 +18,8 @@ PKGS=(
     libreoffice-calc
     libreoffice-impress
     thunderbird
-    evince
     papers
+    evince
     xournalpp
     fonts-noto
 )
@@ -124,7 +124,7 @@ echo "FluxLinux: Installing Email & Organization Tools..."
 # Ubuntu ships thunderbird as a snap transitional deb (24.04+). snapd cannot
 # run under proot and is pointless in chroot, so install only the real deb.
 # Non-fatal: mail is optional, LibreOffice is the headline of this stack.
-if apt-cache depends thunderbird 2>/dev/null | grep -qE 'Depends:[[:space:]]*snapd'; then
+if apt-cache depends thunderbird 2>/dev/null | grep -qE '^[[:space:]]*(Pre)?Depends:[[:space:]]*snapd'; then
     echo " [⚠️] thunderbird in this release is a snap transitional package — skipped."
     echo "      Install a real deb manually if you need it (no PPAs)."
 else
@@ -134,14 +134,15 @@ fi
 
 # 4. PDF Tools
 echo "FluxLinux: Installing PDF Tools..."
-# GNOME renamed Evince to Papers; 26.04 may ship either (evince can be a
-# transitional shim). Try evince, fall back to papers, then xournalpp.
+# GNOME renamed Evince to Papers. On 26.04 papers is the stable release in
+# main (50.x) while evince is still an alpha in universe (49~alpha), so try
+# papers first and keep evince as the fallback for older bases.
 # Non-fatal: LibreOffice can open PDFs anyway.
-if ! apt install -y --no-install-recommends evince 2>/dev/null; then
+if ! apt install -y --no-install-recommends papers 2>/dev/null; then
     apt --fix-broken install -y 2>/dev/null || true
     dpkg --configure -a 2>/dev/null || true
-    apt install -y --no-install-recommends papers 2>/dev/null || \
-        echo " [⚠️] No PDF viewer installed (evince/papers unavailable). LibreOffice can still open PDFs."
+    apt install -y --no-install-recommends evince 2>/dev/null || \
+        echo " [⚠️] No PDF viewer installed (papers/evince unavailable). LibreOffice can still open PDFs."
 fi
 
 apt install -y --no-install-recommends xournalpp 2>/dev/null || \
@@ -159,10 +160,10 @@ verify_installation() {
 
     if command -v libreoffice >/dev/null; then echo " [✅] LibreOffice"; else echo " [❌] LibreOffice Missing"; fi
     if command -v thunderbird >/dev/null; then echo " [✅] Thunderbird"; else echo " [⚠️] Thunderbird Skipped"; fi
-    if command -v evince >/dev/null; then
-        echo " [✅] Evince"
-    elif command -v papers >/dev/null; then
+    if command -v papers >/dev/null; then
         echo " [✅] Papers"
+    elif command -v evince >/dev/null; then
+        echo " [✅] Evince"
     else
         echo " [⚠️] PDF Viewer Missing"
     fi

--- a/app/src/main/kotlin/com/ivarna/fluxlinux/core/data/DistroRepository.kt
+++ b/app/src/main/kotlin/com/ivarna/fluxlinux/core/data/DistroRepository.kt
@@ -224,6 +224,12 @@ object DistroRepository {
     )
     private val ubuntuComponents = glibcXfceComponents(
         "ubuntu/common/setup/setup_ubuntu_family.sh"
+    ) + DistroComponent(
+        id = "office",
+        name = "Office Suite",
+        description = "LibreOffice, PDF Viewer, Email Client.",
+        scriptName = "ubuntu/common/setup/setup_office_ubuntu.sh",
+        sizeEstimate = "500 MB"
     )
     private val kaliComponents = glibcXfceComponents(
         "kali/common/setup/setup_kali_family.sh"

--- a/app/src/test/java/com/ivarna/fluxlinux/core/data/DistroRepositoryTest.kt
+++ b/app/src/test/java/com/ivarna/fluxlinux/core/data/DistroRepositoryTest.kt
@@ -67,7 +67,6 @@ class DistroRepositoryTest {
             "deepin", "deepin_chroot",
             "chimera", "chimera_chroot",
             "manjaro", "manjaro_chroot",
-            "ubuntu", "ubuntu_chroot",
             "kali", "kali_chroot",
             "parrot", "parrot_chroot",
             "archlinux", "archlinux_chroot"
@@ -78,6 +77,19 @@ class DistroRepositoryTest {
             assertTrue(ids.contains("hw_accel"))
             assertTrue(ids.contains("customization"))
             assertEquals(3, ids.size)
+        }
+    }
+
+    @Test
+    fun ubuntuCards_haveBaseComponentsPlusOffice() {
+        listOf("ubuntu", "ubuntu_chroot").forEach { id ->
+            val distro = DistroRepository.supportedDistros.first { it.id == id }
+            val ids = distro.components.map { it.id }
+            assertTrue(ids.contains("xfce4_desktop"))
+            assertTrue(ids.contains("hw_accel"))
+            assertTrue(ids.contains("customization"))
+            assertTrue(ids.contains("office"))
+            assertEquals(4, ids.size)
         }
     }
 

--- a/docs/distro/ubuntu.md
+++ b/docs/distro/ubuntu.md
@@ -20,6 +20,6 @@ Family rewrites DEB822 `ubuntu.sources` URIs from amd64 archive/security to Ubun
 
 - Enables the `universe` component in place (DEB822 `ubuntu.sources` or legacy `sources.list`) — `thunderbird`, `xournalpp`, `npm` and `fonts-noto` are not in `main`. Never appends a new archive or PPA entry.
 - Skips `thunderbird` when the archive package is a snap transitional deb (24.04+), since `snapd` cannot run under proot.
-- Falls back to `papers` when `evince` is unavailable (GNOME renamed it); a missing PDF viewer is non-fatal because LibreOffice opens PDFs.
+- Installs `papers` (GNOME's renamed Evince) rather than `evince`: on 26.04 `papers` is the stable release in `main` (50.x) while `evince` is an alpha in `universe` (49~alpha). `evince` stays as the fallback for older bases, and a missing PDF viewer is non-fatal because LibreOffice opens PDFs.
 
 See [docs/plan/ubuntu-kali-parrot-arch.md](../plan/ubuntu-kali-parrot-arch.md).

--- a/docs/distro/ubuntu.md
+++ b/docs/distro/ubuntu.md
@@ -9,9 +9,17 @@
 | User | `flux` / `flux`, NOPASSWD sudo |
 | Repos | `http://ports.ubuntu.com/ubuntu-ports` only (never `archive.ubuntu.com`) |
 
-Guest scripts: `setup_ubuntu_family.sh`, shared `setup_customization_xfce.sh`, `setup_hw_accel_guest.sh`.  
+Guest scripts: `setup_ubuntu_family.sh`, `setup_office_ubuntu.sh`, shared `setup_customization_xfce.sh`, `setup_hw_accel_guest.sh`.  
 Chroot host: shared `setup_guest_chroot.sh` + `start_guest_gui.sh`.
 
 Family rewrites DEB822 `ubuntu.sources` URIs from amd64 archive/security to Ubuntu Ports. Targeted XFCE (no `ubuntu-desktop`). `xz-utils` installed for guest theme extract.
+
+## Office Suite component
+
+`setup_office_ubuntu.sh` installs LibreOffice, a PDF viewer and Xournal++. Ubuntu-specific handling versus the Debian stack:
+
+- Enables the `universe` component in place (DEB822 `ubuntu.sources` or legacy `sources.list`) — `thunderbird`, `xournalpp`, `npm` and `fonts-noto` are not in `main`. Never appends a new archive or PPA entry.
+- Skips `thunderbird` when the archive package is a snap transitional deb (24.04+), since `snapd` cannot run under proot.
+- Falls back to `papers` when `evince` is unavailable (GNOME renamed it); a missing PDF viewer is non-fatal because LibreOffice opens PDFs.
 
 See [docs/plan/ubuntu-kali-parrot-arch.md](../plan/ubuntu-kali-parrot-arch.md).


### PR DESCRIPTION
Adds the Office Suite component to Ubuntu, the first dev stack ported beyond Debian. Picks up **T7** from `docs/todo/todo.md`.

Ubuntu already had a complete `setup_ubuntu_family.sh`, a pinned rootfs and both PRoot/Chroot cards, but only the base three components (`xfce4_desktop`, `hw_accel`, `customization`). This adds a fourth.

## Not a copy of the Debian script

Three things differ on Ubuntu 26.04 and are handled explicitly:

- **`universe` may not be enabled.** `thunderbird`, `xournalpp`, `npm` and `fonts-noto` are not in `main`. `enable_universe()` rewrites `Components:` in place for DEB822 `ubuntu.sources` and the legacy one-line format. It never appends a new archive line or a PPA, and never touches the `ports.ubuntu.com` URIs the family script sets.
- **`thunderbird` is a snap transitional deb.** On 26.04 the candidate is `2:1snap1-0ubuntu5` with `PreDepends: snapd`. `snapd` cannot run under PRoot, so the script detects this and skips with a warning rather than dragging in a broken install.
- **Evince is now Papers.** `papers` is the stable release in `main` (50.2); `evince` is still an alpha in `universe` (49~alpha). The script installs `papers` and keeps `evince` as the fallback for older bases. A missing PDF viewer is non-fatal since LibreOffice opens PDFs.

Otherwise it follows `setup_office_debian.sh` exactly: standalone bash (helpers are only prepended to *family* scripts), same `PKGS` array, uninstall mode, `handle_error`, and verification block.

## Verification

Run on `ubuntu-24.04-arm` runners against a real `ubuntu:26.04` arm64 container on `ports.ubuntu.com`:

- **End-to-end script run passes.** LibreOffice, `papers` 50.2 and Xournal++ install; thunderbird correctly skipped.
- **The three Ubuntu-specific assumptions above were probed against the live archive**, not assumed. The papers/evince ordering is in this PR *because* the probe caught the first draft installing the alpha.
- **shellcheck clean** at warning severity.
- **Unit tests: 376 run, 2 fail — both pre-existing.** `GuestRootfsShellTest > alpine_absolute_sh_symlink_counts_as_installed` and `OnboardingConsentContractTest > optionsPage_requiresDownloadConsentBeforeInstall` fail identically on unmodified `main` (375 tests, same 2). I ran a baseline specifically to confirm this. You may want to look at those separately — with no CI in the repo they're currently invisible.

## Not verified — please test on a device before merging

Everything above ran in a plain container as root. **The PRoot and Chroot paths are untested**, and that is where dpkg scriptlets and bwrap typically break. Per `.agent/workflows/implement-feature.md` this needs a real install run before it should land.

Relatedly, `enable_universe()` was a no-op in the container image (universe already enabled there). It is idempotent and does not corrupt DEB822 sources, but whether it is actually *needed* on `ubuntu_26.04_rootfs.tar.xz` is unconfirmed. It is cheap insurance either way.

## Note on the test change

`DistroRepositoryTest.newCards_haveComponents` asserted `assertEquals(3, ids.size)` across all seven newer distros. I pulled Ubuntu into its own `ubuntuCards_haveBaseComponentsPlusOffice` asserting 4. If that 3 was a deliberate MVP freeze rather than a snapshot of current state, say so and I will rework it.

Happy to adjust scope, naming, or the component `sizeEstimate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
